### PR TITLE
Find how many HTTP requests it takes to validate a given sub-project

### DIFF
--- a/cmd/kpromo/cmd/pr/pr.go
+++ b/cmd/kpromo/cmd/pr/pr.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pr
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -256,7 +257,7 @@ func runPromote(opts *promoteOptions) error {
 		}
 
 		// If the manifest was not modified, exit now
-		if string(newlist) == string(oldlist) {
+		if bytes.Equal(newlist, oldlist) {
 			logrus.Info("No changes detected in the promoter images list, exiting without changes")
 			return nil
 		}

--- a/hack/count-requests.go
+++ b/hack/count-requests.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type request struct {
+	registry string
+	repo     string
+}
+
+type Manifest struct {
+	ImageSizeBytes string   `json:"imageSizeBytes"`
+	LayerId        string   `json:"layerId"`
+	MediaType      string   `json:"mediaType"`
+	Tag            StrArray `json:"tag"`
+	TimeCreatedMs  string   `json:"timeCreatedMs"`
+	TimeUploadedMs string   `json:"timeUploadedMs"`
+}
+
+type ManifestMap map[string]Manifest
+type StrArray []string
+
+type response struct {
+	Child    StrArray    `json:"child"`
+	Manifest ManifestMap `json:"manifest"`
+	Tags     StrArray    `json:"tags"`
+	Name     string      `json:"name"`
+}
+
+// getSubProjects all sub-projects found in kubernetes/k8s.io.
+func getSubProjects() []string {
+	var cmd *exec.Cmd
+	var out []byte
+	var err error
+
+	fmt.Println("Retrieving all kubernetes/k8s.io sub-projects...")
+
+	// Automate error handling.
+	handle := func(c *exec.Cmd, e error) {
+		if e != nil {
+			fmt.Println("Failed to execute: ", c.String())
+			os.Exit(1)
+		}
+	}
+	// Create a temporary directory.
+	cmd = exec.Command("mktemp", "-d")
+	out, err = cmd.Output()
+	handle(cmd, err)
+	tmpDir := strings.TrimSpace(string(out))
+	// Clone the kubernetes/k8s.io repo.
+	cmd = exec.Command("git", "clone", "https://github.com/kubernetes/k8s.io.git", tmpDir)
+	_, err = cmd.Output()
+	handle(cmd, err)
+	// List the number of sub-projects in the repo.
+	subProjects := fmt.Sprintf("%s/k8s.gcr.io/manifests", tmpDir)
+	cmd = exec.Command("ls", subProjects)
+	out, err = cmd.Output()
+	handle(cmd, err)
+	// Clear the temporary directory.
+	cmd = exec.Command("rm", "-r", tmpDir)
+	_, err = cmd.Output()
+	handle(cmd, err)
+	// Parse the sub-projects into a list of strings.
+	results := []string{}
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		subProject := scanner.Text()
+		if subProject != "README.md" {
+			results = append(results, subProject)
+		}
+	}
+	return results
+}
+
+// genQuery converts the request into an HTTPS query.
+func (r *request) genQuery() string {
+	return fmt.Sprintf("https://%s/v2/%s/tags/list", r.registry, r.repo)
+}
+
+// getPayload converts the HTTP response into a response payload.
+func getPayload(resp *http.Response) response {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	var data response
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		panic(err)
+	}
+	resp.Body.Close()
+	return data
+}
+
+func makeRequest(query string) response {
+	retries := 5
+	var resp *http.Response
+	var err error
+	// Keep requesting until valid response or too many retries.
+	resp, err = http.Get(query)
+	for err != nil {
+		if retries == 0 {
+			panic(query + " could not be reached.")
+		}
+		resp, err = http.Get(query)
+		retries--
+	}
+	// Extract the payload from the HTTP response.
+	return getPayload(resp)
+}
+
+// countQueries returns the total number of HTTP requests needed to validate the request.
+// This total comprises of all children image-prefixes + all manifest lists.
+func (r *request) countQueries() int {
+	query := r.genQuery()
+	payload := makeRequest(query)
+	// We must first count this current query.
+	queries := 1
+	// Recurse over children.
+	for _, child := range payload.Child {
+		c := request{
+			r.registry,
+			r.repo + "/" + child,
+		}
+		// Add up queries made by children.
+		queries += c.countQueries()
+	}
+	// IMPORTANT: The Auditor also makes an HTTP request for every manifest.lists it finds.
+	// Count all manifest lists we see.
+	for _, manifest := range payload.Manifest {
+		if strings.Contains(manifest.MediaType, "manifest.list") {
+			// Found a manifest list.
+			queries++
+		}
+	}
+	return queries
+}
+
+func printUsage() {
+	fmt.Printf("\nUsage: %s [sub-project]\n\n", os.Args[0])
+	fmt.Println(`About: This program finds the total number of HTTP requests to validate a given sub-project.
+If no [sub-project] is given, it aggrigates all sub-projects found in kubernetes/k8s.io and
+finds the sub-project that requires the most requests to validate.`)
+}
+
+func main() {
+	var subProject string
+	if len(os.Args) > 2 {
+		fmt.Println("Invalid number of arguments!")
+		printUsage()
+		os.Exit(1)
+	}
+	if len(os.Args) == 2 {
+		subProject = os.Args[1]
+		r := request{
+			registry: "gcr.io",
+			repo:     subProject,
+		}
+		fmt.Printf("The Auditor would make %d queries to GCR.\n", r.countQueries())
+		return
+	}
+	// Find the sub-project requiring the largest number of queries to verify.
+	maxQueries := 0
+	for _, sp := range getSubProjects() {
+		r := request{
+			registry: "gcr.io",
+			repo:     sp,
+		}
+		numQueries := r.countQueries()
+		fmt.Printf("Sub-project %q requires %d queries.\n", sp, numQueries)
+		if maxQueries < numQueries {
+			maxQueries = numQueries
+			subProject = sp
+		}
+	}
+	fmt.Printf("[MAX] %q takes %d queries to verify.\n", subProject, maxQueries)
+}

--- a/hack/count-requests.go
+++ b/hack/count-requests.go
@@ -34,7 +34,7 @@ type request struct {
 
 type Manifest struct {
 	ImageSizeBytes string   `json:"imageSizeBytes"`
-	LayerId        string   `json:"layerId"`
+	LayerID        string   `json:"layerId"`
 	MediaType      string   `json:"mediaType"`
 	Tag            StrArray `json:"tag"`
 	TimeCreatedMs  string   `json:"timeCreatedMs"`
@@ -42,6 +42,7 @@ type Manifest struct {
 }
 
 type ManifestMap map[string]Manifest
+
 type StrArray []string
 
 type response struct {
@@ -117,20 +118,22 @@ func getPayload(resp *http.Response) response {
 }
 
 func makeRequest(query string) response {
-	retries := 5
 	var resp *http.Response
+	var payload response
 	var err error
+
 	// Keep requesting until valid response or too many retries.
-	resp, err = http.Get(query)
-	for err != nil {
-		if retries == 0 {
+	for retries := 5; retries >= 1; retries-- {
+		resp, err = http.Get(query)
+		if err == nil {
+			payload = getPayload(resp)
+		} else if retries == 0 {
 			panic(query + " could not be reached.")
 		}
-		resp, err = http.Get(query)
-		retries--
 	}
+
 	// Extract the payload from the HTTP response.
-	return getPayload(resp)
+	return payload
 }
 
 // countQueries returns the total number of HTTP requests needed to validate the request.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is a proof-of-concept tool in order to determine how much network usage a given sub-project will demand of the Auditor. It counts all unique image prefixes and manifest lists to determine the total number of HTTP requests required to validate an image originated form the given sub-project.

#### Which issue(s) this PR fixes:
Part of #392 & #353
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Not meant for review or merge.

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Created a script to find how many HTTP requests it takes to validate a given sub-project.
```
