### PR TITLE
drop wg/k8s-infra label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug encountered while using container image promoter tooling
-labels: kind/bug, sig/release, area/release-eng, wg/k8s-infra
+labels: kind/bug, sig/release, area/release-eng
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Suggest a feature for Kubernetes container image promoter tooling
-labels: kind/feature, sig/release, area/release-eng, wg/k8s-infra
+labels: kind/feature, sig/release, area/release-eng
 
 ---
 <!-- Please only use this template for submitting feature requests -->

--- a/OWNERS
+++ b/OWNERS
@@ -12,4 +12,3 @@ labels:
 - sig/release
 - area/artifacts
 - area/release-eng
-- wg/k8s-infra


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Part of:
- https://github.com/kubernetes/community/issues/6036

Let's stop labeling everything for k8s-infra by default now that it's a SIG.

While SIG k8s-infra collaborates on the deployment and use of tooling
built from code in this repo, we're not (as a group) owners of this
code..

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE

```