### PR TITLE
Dockerfile: Restore Docker configuration to production container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim AS base
 
 WORKDIR /
 COPY --from=builder /go/src/app/bin/kpromo .
+COPY --from=builder /go/src/app/docker/config.json /.docker/config.json
 
 ENTRYPOINT ["/kpromo"]
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMG_VERSION: 'v3.3.0-beta.0-1'
+  _IMG_VERSION: 'v3.3.0-beta.0-2'
 
 tags:
 - 'kpromo'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "k8s.gcr.io/artifact-promoter/kpromo"
-    version: v3.3.0-beta.0-1
+    version: v3.3.0-beta.0-2
     refPaths:
     - path: cloudbuild.yaml
       match: "_IMG_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)-([0-9]+)'"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -65,7 +65,7 @@ p_ IMG_REGISTRY gcr.io
 p_ IMG_REPOSITORY k8s-staging-artifact-promoter
 p_ IMG_NAME kpromo
 p_ IMG_TAG "${image_tag}"
-p_ IMG_VERSION v3.3.0-beta.0-1
+p_ IMG_VERSION v3.3.0-beta.0-2
 p_ TEST_AUDIT_PROD_IMG_REPOSITORY us.gcr.io/k8s-gcr-audit-test-prod
 p_ TEST_AUDIT_STAGING_IMG_REPOSITORY gcr.io/k8s-gcr-audit-test-prod
 p_ TEST_AUDIT_PROJECT_ID k8s-gcr-audit-test-prod


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

- Dockerfile: Restore Docker configuration to production container
  The config.json Docker configuration file stored in this repo
  contains credential helper information necessary to direct the
  promoter to use `gcloud` when attempting to authenticate to GCR.
  
  Without it, image promotion jobs will fail.
  
  ref: https://cloud.google.com/container-registry/docs/advanced-authentication
- Build v3.3.0-beta.0-2 images

Discovered in https://github.com/kubernetes/k8s.io/issues/2877 / https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-image-promo/1445119208047251456

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Dockerfile: Restore Docker configuration to production container
  The config.json Docker configuration file stored in this repo
  contains credential helper information necessary to direct the
  promoter to use `gcloud` when attempting to authenticate to GCR.
  
  Without it, image promotion jobs will fail.
  
  ref: https://cloud.google.com/container-registry/docs/advanced-authentication
- Build v3.3.0-beta.0-2 images
```
