### PR TITLE
Dockerfile: Copy Docker config file to `$HOME/.docker/config.json`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,12 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim AS base
 
 WORKDIR /
 COPY --from=builder /go/src/app/bin/kpromo .
-COPY --from=builder /go/src/app/docker/config.json /.docker/config.json
+
+# The Docker configuration file (which include credential helpers for
+# authenticating to various container registries) should be placed in the home
+# directory of the running user, so it can be detected by artifact promotion
+# tooling.
+COPY --from=builder /go/src/app/docker/config.json $HOME/.docker/config.json
 
 ENTRYPOINT ["/kpromo"]
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMG_VERSION: 'v3.3.0-beta.1-1'
+  _IMG_VERSION: 'v3.3.0-beta.1-2'
 
 tags:
 - 'kpromo'

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
       match: go \d+.\d+
 
   - name: "k8s.gcr.io/artifact-promoter/kpromo"
-    version: v3.3.0-beta.1-1
+    version: v3.3.0-beta.1-2
     refPaths:
     - path: cloudbuild.yaml
       match: "_IMG_VERSION: 'v((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)-([0-9]+)'"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -65,7 +65,7 @@ p_ IMG_REGISTRY gcr.io
 p_ IMG_REPOSITORY k8s-staging-artifact-promoter
 p_ IMG_NAME kpromo
 p_ IMG_TAG "${image_tag}"
-p_ IMG_VERSION v3.3.0-beta.1-1
+p_ IMG_VERSION v3.3.0-beta.1-2
 p_ TEST_AUDIT_PROD_IMG_REPOSITORY us.gcr.io/k8s-gcr-audit-test-prod
 p_ TEST_AUDIT_STAGING_IMG_REPOSITORY gcr.io/k8s-gcr-audit-test-prod
 p_ TEST_AUDIT_PROJECT_ID k8s-gcr-audit-test-prod


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/k8s.io/issues/2877.

We restored the Docker configuration file in #442, but that didn't resolve the `UNAUTHORIZED` errors we were observing. The `post-k8sio-image-promo` job is still failing and here are some logs from the recent run which uses the `k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2` image: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-image-promo/1445772988132626432

We were setting the `HOME` environment variable to `/` in the old image (`k8s.gcr.io/artifact-promoter/cip:v3.2.0`), however, we're not doing that any longer. Running `echo $HOME` in the container that uses the `k8s.gcr.io/artifact-promoter/kpromo:v3.3.0-beta.0-2` returns `/root`, while running the same command in the container that uses the `k8s.gcr.io/artifact-promoter/cip:v3.2.0` image returns `/`.

The Docker configuration file (which include credential helpers for
authenticating to various container registries) should be placed in the home
directory of the running user, so it can be detected by artifact promotion
tooling.

This PR also builds the kpromo v3.3.0-beta.1-2 images.

Signed-off-by: Marko Mudrinić <mudrinic.mare@gmail.com>
Co-authored-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- Dockerfile: Copy Docker config file to `$HOME/.docker/config.json`
  
  The Docker configuration file (which include credential helpers for
  authenticating to various container registries) should be placed in the home
  directory of the running user, so it can be detected by artifact promotion
  tooling.
- Build v3.3.0-beta.1-2 images
```
