### PR TITLE
kpromo pr: Allow sorting output manifest by tags instead of digest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/grafeas v0.1.0 // indirect
 	cloud.google.com/go/logging v1.4.2
 	cloud.google.com/go/storage v1.21.0
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.1-0.20220216220642-00c59d91847c
@@ -84,7 +85,6 @@ require (
 	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/image/image.go
+++ b/image/image.go
@@ -92,8 +92,10 @@ func (imagesList *ManifestList) Write(filePath string) error {
 // ToYAML serializes an image list into an YAML file.
 // We serialize the data by hand to emulate the way it's done by the image promoter
 func (imagesList *ManifestList) ToYAML() ([]byte, error) {
-	// The image promoter code sorts images by:
-	//	  1. Name 2. Digest SHA (asc)  3. Tag
+	// Images are sorted by:
+	//	  1. Name 2. Tag
+	// If there are multiple tags for a single image digest, the smallest tag is used in the sort.''
+	// Image tags are sorted lexicographically as they are not guaranteed to be Semver compliant. See https://github.com/opencontainers/distribution-spec/issues/154 fpr more details.
 
 	// First, sort by name (sort #1)
 	sort.Slice(*imagesList, func(i, j int) bool {
@@ -107,15 +109,9 @@ func (imagesList *ManifestList) ToYAML() ([]byte, error) {
 		yamlCode += fmt.Sprintf("- name: %s\n", imgData.Name)
 		yamlCode += "  dmap:\n"
 
-		// Now, lets sort by the digest sha (sort #2)
-		keys := make([]string, 0, len(imgData.DMap))
-		for k := range imgData.DMap {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
+		sortedDigests := sortImageDigestMapByTag(imgData.DMap)
 
-		for _, digestSHA := range keys {
-			// Finally, sort bt tag (sort #3)
+		for _, digestSHA := range sortedDigests {
 			tags := imgData.DMap[digestSHA]
 			sort.Strings(tags)
 			yamlCode += fmt.Sprintf("    %q: [", digestSHA)
@@ -130,4 +126,32 @@ func (imagesList *ManifestList) ToYAML() ([]byte, error) {
 	}
 
 	return []byte(yamlCode), nil
+}
+
+func sortImageDigestMapByTag(imageDMap map[string][]string) []string {
+	var sortedDigests []string
+	// we need to sort the map by value (tags)
+	tags := make([]string, 0, len(imageDMap))
+	valuesToKeys := make(map[string][]string)
+	for k, v := range imageDMap {
+		// find the smallest tag for each image digest
+		sort.Strings(v)
+		first := v[0]
+		// and add it to the list of tags
+		if _, ok := valuesToKeys[first]; !ok {
+			tags = append(tags, first)
+		}
+		valuesToKeys[first] = append(valuesToKeys[first], k)
+	}
+	// Then, sort the tags lexicographically
+	sort.Strings(tags)
+
+	for _, v := range tags {
+		// for each version, add the corresponding digest SHA to the list of sorted digests.
+		digests := valuesToKeys[v]
+		sort.Strings(digests) // in the unlikely case that there are multiple tags for the same digest, we sort them to make sure this function is deterministic
+		sortedDigests = append(sortedDigests, digests...)
+	}
+
+	return sortedDigests
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -18,6 +18,7 @@ package image
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,13 +103,13 @@ func TestPromoterImageToYAML(t *testing.T) {
 		},
 	}
 
-	// Expected yaml output, must be sorted correctly, according to the image promoter sort order
+	// Expected yaml output
 	expectedYAML := "- name: conformance\n  dmap:\n"
 	expectedYAML += "    \"sha256:17fcac56c871a58a093ff36915816161b1dbbb9eca0add9c968d9c27c4ba1881\": [\"v1.19.0\"]\n"
 	expectedYAML += "- name: hyperkube\n  dmap:\n"
 	expectedYAML += "    \"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342\": [\"v1.16.16-rc.0\"]\n"
-	expectedYAML += "    \"sha256:54cdd8d3b74f9c577c8bb4f43e50813f0190006e66efe861bd810ee3f5e7cc7d\": [\"v1.18.8\"]\n"
 	expectedYAML += "    \"sha256:9f35b65ee834239ffbbd0ddfb54e0317cf99f10a75d8e8af372af45286d069ab\": [\"v1.17.10\"]\n"
+	expectedYAML += "    \"sha256:54cdd8d3b74f9c577c8bb4f43e50813f0190006e66efe861bd810ee3f5e7cc7d\": [\"v1.18.8\"]\n"
 	expectedYAML += "- name: kube-proxy\n  dmap:\n"
 	expectedYAML += "    \"sha256:c752ecbd04bc4517168a19323bb60fb45324eee1e480b2b97d3fd6ea0a54f42d\": [\"v1.18.8\",\"v1.19.0\"]\n"
 
@@ -126,6 +127,7 @@ func TestPromoterImageWrite(t *testing.T) {
 			Name: "kube-controller-manager-s390x",
 			DMap: map[string][]string{
 				"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7": {"v1.19.1"},
+				"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342": {"v1.19.2"},
 			},
 		},
 		struct {
@@ -139,21 +141,97 @@ func TestPromoterImageWrite(t *testing.T) {
 		},
 	}
 
+	// Expected yaml output, must be sorted correctly, according to the image promoter sort order.
 	expectedFile := "- name: kube-controller-manager-s390x\n  dmap:\n"
 	expectedFile += "    \"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7\": [\"v1.19.1\"]\n"
+	expectedFile += "    \"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342\": [\"v1.19.2\"]\n"
 	expectedFile += "- name: kube-scheduler\n  dmap:\n"
 	expectedFile += "    \"sha256:022b81d70447014f63fdc734df48cb9e3a2854c48f65acdca67aac5c1974fc22\": [\"v1.19.0-rc.2\"]\n"
 
-	tempFile, err := os.CreateTemp("", "release-test")
+	tempFileSorted, err := os.CreateTemp("", "release-test")
 	require.Nil(t, err, "creating temp file")
-	defer os.Remove(tempFile.Name())
+	defer os.Remove(tempFileSorted.Name())
 
-	err = imageList.Write(tempFile.Name())
+	err = imageList.Write(tempFileSorted.Name())
 	require.Nil(t, err, "writing data to disk")
 
 	// Read back the file to see if it correct
-	fileContents, err := os.ReadFile(tempFile.Name())
+	fileContents, err := os.ReadFile(tempFileSorted.Name())
 	require.Nil(t, err, "reading temporary file")
 
 	require.Equal(t, expectedFile, string(fileContents))
+}
+
+func Test_sortImageDigestMapByTag(t *testing.T) {
+	tests := []struct {
+		name string
+		dmap map[string][]string
+		want []string
+	}{
+		{
+			name: "image digests are sorted by tags",
+			dmap: map[string][]string{
+				"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342": {"v1.1.2"},
+				"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7": {"v1.1.1"},
+			},
+			want: []string{
+				"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7",
+				"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342",
+			},
+		},
+		{
+			name: "multiple tags by image",
+			dmap: map[string][]string{
+				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8": {"v2.1.0", "v2.1.3"},
+				"sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352": {"v2.1.1", "v2.1.2"},
+			},
+			want: []string{
+				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8",
+				"sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352",
+			},
+		},
+		{
+			name: "non semver-compliant tags",
+			dmap: map[string][]string{
+				"sha256:08c14f378308dd053bca28f64ab4cbfbca469c8ce5b2831fc3c267adbdc2ae6a": {"buster-v1.7.0"},
+				"sha256:1c81250e8dc13a7b1c9fbd7a7f47843e1bc7c66cbf308f315772b88673a82bf2": {"buster-v1.6.0"},
+				"sha256:1e76a235c477dfe46d707d2be80a835b44cdcf6f35675fb2189c7a28b6d09878": {"buster-v1.9.0"},
+				"sha256:22666783ee41fa619ad4d7ea40800bb40901d2e27d60c0ca3339a5851374763e": {"buster-v1.8.0"},
+				"sha256:248087165d8f4d901e27a799f10fe4b7b4458469191120385317ad32aa5e3382": {"buster-v1.10.0"},
+				"sha256:2f37650255a457d0fc3a5c685ac1eecb5e0f16c63b58b82e52a585fff0aabff6": {"buster-v1.7.2"},
+				"sha256:36652ef8e4dd6715de02e9b68e5c122ed8ee06c75f83f5c574b97301e794c3fb": {"buster-v1.4.0"},
+				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8": {"buster-v1.1.3", "v2.1.3"},
+				"sha256:51af4a1e8821f550a5639096f48b88c746118a65832465fc6d22de73cea99985": {"buster-v1.5.0"},
+			},
+			want: []string{
+				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8",
+				"sha256:248087165d8f4d901e27a799f10fe4b7b4458469191120385317ad32aa5e3382",
+				"sha256:36652ef8e4dd6715de02e9b68e5c122ed8ee06c75f83f5c574b97301e794c3fb",
+				"sha256:51af4a1e8821f550a5639096f48b88c746118a65832465fc6d22de73cea99985",
+				"sha256:1c81250e8dc13a7b1c9fbd7a7f47843e1bc7c66cbf308f315772b88673a82bf2",
+				"sha256:08c14f378308dd053bca28f64ab4cbfbca469c8ce5b2831fc3c267adbdc2ae6a",
+				"sha256:2f37650255a457d0fc3a5c685ac1eecb5e0f16c63b58b82e52a585fff0aabff6",
+				"sha256:22666783ee41fa619ad4d7ea40800bb40901d2e27d60c0ca3339a5851374763e",
+				"sha256:1e76a235c477dfe46d707d2be80a835b44cdcf6f35675fb2189c7a28b6d09878",
+			},
+		},
+		{
+			name: "two images with same tag",
+			dmap: map[string][]string{
+				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8": {"v2.1.0"},
+				"sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352": {"v2.1.0"},
+			},
+			want: []string{
+				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8",
+				"sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sortImageDigestMapByTag(tt.dmap); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sortImageDigestMapByTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
This PRs allows optionally sorting manifests by tag so they are easier to review by human reviewers. The default is the current behavior of sorting by image digest.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #473 

or

None
-->

Fixes #473 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kpromo pr: Allow sorting output manifest by tags instead of digest
```
