### PR TITLE
Move `cip-mm` to `kpromo mm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,16 @@ kpromo:
 	${REPO_ROOT}/go_with_version.sh build -trimpath -ldflags '-s -w -buildid= -extldflags "-static" $(LDFLAGS)' -o ./bin/kpromo ./cmd/kpromo
 
 .PHONY: cip-mm
-cip-mm:
-	${REPO_ROOT}/go_with_version.sh build -trimpath -o ./bin/cip-mm ./cmd/cip-mm
+cip-mm: kpromo
 
 ##@ Build
 .PHONY: build
-build: kpromo cip-mm ## Build go tools within the repository
+build: kpromo ## Build go tools within the repository
 	${REPO_ROOT}/go_with_version.sh build -o ./bin/cip-auditor-e2e ${REPO_ROOT}/test-e2e/cip-auditor/cip-auditor-e2e.go
 	${REPO_ROOT}/go_with_version.sh build -o ./bin/cip-e2e ${REPO_ROOT}/test-e2e/cip/e2e.go
 
 .PHONY: install
 install: build ## Install
-	${REPO_ROOT}/go_with_version.sh install ${REPO_ROOT}/cmd/cip-mm
 	${REPO_ROOT}/go_with_version.sh install ${REPO_ROOT}/cmd/kpromo
 
 ##@ Images

--- a/cmd/cip-mm/README.md
+++ b/cmd/cip-mm/README.md
@@ -1,40 +1,7 @@
 # cip-mm
 
-This tool **m**odifies promoter **m**anifests. For now it dumps some filtered
-subset of a staging GCR and merges those contents back into a given promoter
-manifest.
+`cip-mm` is deprecated and will be removed in a future release.
 
-## Examples
-
-- Add all images with a matching digest from staging repo
-  `gcr.io/k8s-staging-artifact-promoter` to a manifest, using the name and tags
-  already existing in the staging repo:
-
-```
-cip-mm \
-  --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
-  --staging_repo=gcr.io/k8s-staging-artifact-promoter \
-  --filter_digest=sha256:7594278deaf6eeaa35caedec81796d103e3c83a26d7beab091a5d25a9ba6aa16
-```
-
-- Add a single image named "foo" and tagged "1.0" from staging repo
-  `gcr.io/k8s-staging-artifact-promoter` to a manifest:
-
-```
-cip-mm \
-  --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
-  --staging_repo=gcr.io/k8s-staging-artifact-promoter \
-  --filter_image=cip \
-  --filter_tag=1.0
-```
-
-- Add all images tagged `1.0` from staging repo
-  `gcr.io/k8s-staging-artifact-promoter` to a manifest:
-
-```
-cip-mm \
-  --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
-  --staging_repo=gcr.io/k8s-staging-artifact-promoter \
-  --filter_image=cip \
-  --filter_tag=1.0
-```
+These instructions will temporarily remain for existing consumers
+(as `kpromo mm`), but please begin to use
+[`kpromo pr`](docs/promotion-pull-requests.md) instead.

--- a/cmd/kpromo/cmd/mm/mm.go
+++ b/cmd/kpromo/cmd/mm/mm.go
@@ -14,101 +14,82 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package mm
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	reg "sigs.k8s.io/promo-tools/v3/legacy/dockerregistry"
-	"sigs.k8s.io/release-utils/log"
 )
 
-var cmd = &cobra.Command{
-	Short: "cip-mm → Container Image Promoter - Manifest Modificator",
-	Long: `cip-mm → Container Image Promoter - Manifest Modificator
+// TODO(cip-mm): Remove in the next minor release.
+
+var MMCmd = &cobra.Command{
+	Short: "[DEPRECATED] mm → Manifest Modifier",
+	Long: `[DEPRECATED] mm → Manifest Modifier
 
 This tool **m**odifies promoter **m**anifests. For now it dumps some filtered
 subset of a staging GCR and merges those contents back into a given promoter
 manifest.`,
-	Use:               "cip-mm",
-	SilenceUsage:      true,
-	SilenceErrors:     true,
-	PersistentPreRunE: initLogging,
+	Use:           "mm",
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return run()
 	},
 }
 
-type commandLineOptions struct {
+type modifyOptions struct {
 	baseDir      string
 	stagingRepo  string
 	filterImage  string
 	filterDigest string
 	filterTag    string
-	logLevel     string
 }
 
-var commandLineOpts = &commandLineOptions{}
+var modifyOpts = &modifyOptions{}
 
 func init() {
-	cmd.PersistentFlags().StringVar(
-		&commandLineOpts.baseDir,
+	MMCmd.PersistentFlags().StringVar(
+		&modifyOpts.baseDir,
 		"base_dir",
 		"",
 		"the manifest directory to look at and modify",
 	)
-	cmd.PersistentFlags().StringVar(
-		&commandLineOpts.stagingRepo,
+	MMCmd.PersistentFlags().StringVar(
+		&modifyOpts.stagingRepo,
 		"staging_repo",
 		"",
 		"the staging repo which we want to read from",
 	)
-	cmd.PersistentFlags().StringVar(
-		&commandLineOpts.filterImage,
+	MMCmd.PersistentFlags().StringVar(
+		&modifyOpts.filterImage,
 		"filter_image",
 		"",
 		"filter staging repo by this image name",
 	)
-	cmd.PersistentFlags().StringVar(
-		&commandLineOpts.filterDigest,
+	MMCmd.PersistentFlags().StringVar(
+		&modifyOpts.filterDigest,
 		"filter_digest",
 		"",
 		"filter images by this digest",
 	)
-	cmd.PersistentFlags().StringVar(
-		&commandLineOpts.filterTag,
+	MMCmd.PersistentFlags().StringVar(
+		&modifyOpts.filterTag,
 		"filter_tag",
 		"",
 		"filter images by this tag",
 	)
-	cmd.PersistentFlags().StringVar(
-		&commandLineOpts.logLevel,
-		"log-level",
-		"info",
-		fmt.Sprintf("the logging verbosity, either %s", log.LevelNames()),
-	)
-}
-
-func main() {
-	if err := cmd.Execute(); err != nil {
-		logrus.Fatal(err)
-	}
-}
-
-func initLogging(*cobra.Command, []string) error {
-	return log.SetupGlobalLogger(commandLineOpts.logLevel)
 }
 
 func run() error {
 	opt := reg.GrowManifestOptions{}
 	if err := opt.Populate(
-		commandLineOpts.baseDir, commandLineOpts.stagingRepo,
-		commandLineOpts.filterImage, commandLineOpts.filterDigest,
-		commandLineOpts.filterTag); err != nil {
+		modifyOpts.baseDir, modifyOpts.stagingRepo,
+		modifyOpts.filterImage, modifyOpts.filterDigest,
+		modifyOpts.filterTag); err != nil {
 		return err
 	}
 

--- a/cmd/kpromo/cmd/pr/pr.go
+++ b/cmd/kpromo/cmd/pr/pr.go
@@ -375,3 +375,18 @@ func generatePRBody(opts *promoteOptions) string {
 
 	return prBody
 }
+
+// `cip-mm` functionality
+// Punchlist for `cip-mm` deprecation
+// - TODO(cip-mm): Support local workflow
+//                 - stage changes, but don't commit or push?
+//                 - stage changes and commit, but don't push?
+//                 - point at local directory instead of virtual repo?
+// - TODO(cip-mm): Support filtering by image name
+// - TODO(cip-mm): Support filtering by digest
+// - TODO(cip-mm): Support filtering by tag
+// - TODO(cip-mm): Fix spacing in tag list
+//                 ref: https://github.com/kubernetes/k8s.io/pull/3212/files#r771604521
+// - TODO(cip-mm): Confirm options are validated
+// - TODO(cip-mm): Ensure filtering options support multiple values
+// - TODO(cip-mm): Support non-SemVer image tags

--- a/cmd/kpromo/cmd/root.go
+++ b/cmd/kpromo/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/cip"
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/gh"
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/manifest"
+	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/mm"
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/pr"
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/run"
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/version"
@@ -80,6 +81,8 @@ func init() {
 	rootCmd.AddCommand(manifest.ManifestCmd)
 	rootCmd.AddCommand(pr.PRCmd)
 	rootCmd.AddCommand(version.VersionCmd)
+	// TODO(cip-mm): Remove in the next minor release.
+	rootCmd.AddCommand(mm.MMCmd)
 }
 
 func initLogging(*cobra.Command, []string) error {

--- a/docs/promotion-pull-requests.md
+++ b/docs/promotion-pull-requests.md
@@ -7,6 +7,9 @@ Please feel free to propose PRs to adjust the language as needed.
 - [Preparing Environment](#preparing-environment)
 - [Promoting Images](#promoting-images)
 - [Completing the Image Promotion](#completing-the-image-promotion)
+- [Deprecated](#deprecated)
+  - [`cip-mm`](#cip-mm)
+    - [Examples](#examples)
 
 When cutting a new Kubernetes release, we need to publish images to the `k8s-staging-kubernetes` GCS Bucket and then promote them to the production.
 
@@ -92,3 +95,52 @@ Once the `kpromo pr` command is done take the following steps to complete image 
   - If you're cutting Alpha, Beta, or RC release, lift the hold and proceed with the release process
   - If you're cutting a stable release, ensure that a [Build Admin](https://kubernetes.io/releases/release-managers/#build-admins) is available to cut the packages before lifting the hold and proceeding with the release
 - After the Pull Request is merged and **before** starting the `Official Release` step, we need to watch the following [Prow Job](https://prow.k8s.io/?job=post-k8sio-image-promo) to succeed. When the latest master ran without errors, then we can continue with `Official Release`.
+
+## Deprecated
+
+### `cip-mm`
+
+`cip-mm` is deprecated and will be removed in a future release.
+
+These instructions will temporarily remain for existing consumers
+(as `kpromo mm`), but please begin to use `kpromo pr` (which is described in
+more detail above) instead.
+
+This tool **m**odifies promoter **m**anifests. For now it dumps some filtered
+subset of a staging GCR and merges those contents back into a given promoter
+manifest.
+
+#### Examples
+
+- Add all images with a matching digest from staging repo
+  `gcr.io/k8s-staging-artifact-promoter` to a manifest, using the name and tags
+  already existing in the staging repo:
+
+  ```console
+  kpromo mm \
+    --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
+    --staging_repo=gcr.io/k8s-staging-artifact-promoter \
+    --filter_digest=sha256:7594278deaf6eeaa35caedec81796d103e3c83a26d7beab091a5d25a9ba6aa16
+  ```
+
+- Add a single image named "foo" and tagged "1.0" from staging repo
+  `gcr.io/k8s-staging-artifact-promoter` to a manifest:
+
+  ```console
+  kpromo mm \
+    --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
+    --staging_repo=gcr.io/k8s-staging-artifact-promoter \
+    --filter_image=cip \
+    --filter_tag=1.0
+  ```
+
+- Add all images tagged `1.0` from staging repo
+  `gcr.io/k8s-staging-artifact-promoter` to a manifest:
+
+  ```console
+  kpromo mm \
+    --base_dir=$HOME/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io  \
+    --staging_repo=gcr.io/k8s-staging-artifact-promoter \
+    --filter_image=cip \
+    --filter_tag=1.0
+  ```


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup deprecation

#### What this PR does / why we need it:

Part one of https://github.com/kubernetes-sigs/promo-tools/issues/508:

- cip-mm: Add deprecation notices in documentation and remove targets
- Move `cip-mm` to `kpromo mm`
- kpromo(pr): Add cip-mm deprecation punchlist

Signed-off-by: Stephen Augustus <foo@auggie.dev>

ref: https://github.com/kubernetes-sigs/promo-tools/issues/473#issuecomment-991167871

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- cip-mm: Add deprecation notices in documentation and remove targets
- Move `cip-mm` to `kpromo mm`
```
