### PR TITLE
dockerregistry: Initial refactor to reduce package complexity

### DIFF
--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -142,7 +142,7 @@ func Grow(
 	var riiCombined registry.RegInvImage
 
 	// (1) Scan the BaseDir and find the promoter manifest to modify.
-	manifest, err := Find(o)
+	mfest, err := Find(o)
 	if err != nil {
 		return err
 	}
@@ -162,19 +162,19 @@ func Grow(
 
 	// (4) Inject (2)'s output into (1)'s manifest's images to create a larger
 	// RegInvImage.
-	riiCombined = Union(manifest.ToRegInvImage(), riiFiltered)
+	riiCombined = Union(mfest.ToRegInvImage(), riiFiltered)
 
 	// (5) Write back RegInvImage as Manifest ([]Image field}) back onto disk.
-	err = Write(manifest, riiCombined)
+	err = Write(mfest, riiCombined)
 
 	return err
 }
 
 // Write writes images as YAML out to the expected path of the given
 // (thin) manifest.
-func Write(manifest manifest.Manifest, rii registry.RegInvImage) error {
+func Write(m manifest.Manifest, rii registry.RegInvImage) error {
 	// Chop off trailing "promoter-manifest.yaml".
-	p := path.Dir(manifest.Filepath)
+	p := path.Dir(m.Filepath)
 	// Get staging repo directory name as it is laid out in the thin manifest
 	// dir.
 	stagingRepoName := path.Base(p)
@@ -214,13 +214,13 @@ func Find(o *GrowOptions) (manifest.Manifest, error) {
 func ReadStagingRepo(
 	o *GrowOptions,
 ) (registry.RegInvImage, error) {
-	stagingRepoRC := registry.RegistryContext{
+	stagingRepoRC := registry.Context{
 		Name: o.StagingRepo,
 	}
 
 	manifests := []manifest.Manifest{
 		{
-			Registries: []registry.RegistryContext{
+			Registries: []registry.Context{
 				stagingRepoRC,
 			},
 			Images: []registry.Image{},
@@ -236,7 +236,7 @@ func ReadStagingRepo(
 		return registry.RegInvImage{}, err
 	}
 	sc.ReadRegistries(
-		[]registry.RegistryContext{stagingRepoRC},
+		[]registry.Context{stagingRepoRC},
 		// Read all registries recursively, because we want to produce a
 		// complete snapshot.
 		true,

--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -26,8 +26,8 @@ import (
 	"golang.org/x/xerrors"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
 
@@ -171,8 +171,8 @@ func Grow(
 }
 
 // Write writes images as YAML out to the expected path of the given
-// (thin) manifest.
-func Write(m manifest.Manifest, rii registry.RegInvImage) error {
+// (thin) schema.
+func Write(m schema.Manifest, rii registry.RegInvImage) error {
 	// Chop off trailing "promoter-manifest.yaml".
 	p := path.Dir(m.Filepath)
 	// Get staging repo directory name as it is laid out in the thin manifest
@@ -190,12 +190,12 @@ func Write(m manifest.Manifest, rii registry.RegInvImage) error {
 }
 
 // Find finds the manifest to modify.
-func Find(o *GrowOptions) (manifest.Manifest, error) {
+func Find(o *GrowOptions) (schema.Manifest, error) {
 	var err error
-	var manifests []manifest.Manifest
-	manifests, err = manifest.ParseThinManifestsFromDir(o.BaseDir)
+	var manifests []schema.Manifest
+	manifests, err = schema.ParseThinManifestsFromDir(o.BaseDir)
 	if err != nil {
-		return manifest.Manifest{}, err
+		return schema.Manifest{}, err
 	}
 
 	logrus.Infof("%d manifests parsed", len(manifests))
@@ -204,13 +204,13 @@ func Find(o *GrowOptions) (manifest.Manifest, error) {
 			return manifest, nil
 		}
 	}
-	return manifest.Manifest{},
+	return schema.Manifest{},
 		xerrors.Errorf("could not find Manifest for %q", o.StagingRepo)
 }
 
 // ReadStagingRepo reads the StagingRepo, and applies whatever filters are
 // available to the resulting RegInvImage. This RegInvImage is what we want to
-// inject into the "images.yaml" of a thin manifest.
+// inject into the "images.yaml" of a thin schema.
 func ReadStagingRepo(
 	o *GrowOptions,
 ) (registry.RegInvImage, error) {
@@ -218,7 +218,7 @@ func ReadStagingRepo(
 		Name: o.StagingRepo,
 	}
 
-	manifests := []manifest.Manifest{
+	manifests := []schema.Manifest{
 		{
 			Registries: []registry.Context{
 				stagingRepoRC,

--- a/image/manifest/manifest_test.go
+++ b/image/manifest/manifest_test.go
@@ -43,7 +43,7 @@ func testPath(paths ...string) string {
 
 func TestFind(t *testing.T) {
 	pwd := testPath()
-	srcRC := registry.RegistryContext{
+	srcRC := registry.Context{
 		Name:           "gcr.io/foo-staging",
 		ServiceAccount: "sa@robot.com",
 		Src:            true,
@@ -76,7 +76,7 @@ func TestFind(t *testing.T) {
 				StagingRepo: "gcr.io/foo-staging",
 			},
 			regmanifest.Manifest{
-				Registries: []registry.RegistryContext{
+				Registries: []registry.Context{
 					srcRC,
 					{
 						Name:           "us.gcr.io/some-prod",

--- a/image/manifest/manifest_test.go
+++ b/image/manifest/manifest_test.go
@@ -26,8 +26,8 @@ import (
 	"golang.org/x/xerrors"
 
 	"sigs.k8s.io/promo-tools/v3/image/manifest"
-	regmanifest "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
 
@@ -53,7 +53,7 @@ func TestFind(t *testing.T) {
 		// name is folder name
 		name             string
 		input            manifest.GrowOptions
-		expectedManifest regmanifest.Manifest
+		expectedManifest schema.Manifest
 		expectedErr      error
 	}{
 		{
@@ -62,7 +62,7 @@ func TestFind(t *testing.T) {
 				BaseDir:     filepath.Join(pwd, "empty"),
 				StagingRepo: "gcr.io/foo",
 			},
-			regmanifest.Manifest{},
+			schema.Manifest{},
 			&os.PathError{
 				Op:   "stat",
 				Path: filepath.Join(pwd, "empty/images"),
@@ -75,7 +75,7 @@ func TestFind(t *testing.T) {
 				BaseDir:     filepath.Join(pwd, "singleton"),
 				StagingRepo: "gcr.io/foo-staging",
 			},
-			regmanifest.Manifest{
+			schema.Manifest{
 				Registries: []registry.Context{
 					srcRC,
 					{
@@ -109,7 +109,7 @@ func TestFind(t *testing.T) {
 				BaseDir:     filepath.Join(pwd, "singleton"),
 				StagingRepo: "gcr.io/nonsense-staging",
 			},
-			regmanifest.Manifest{},
+			schema.Manifest{},
 			fmt.Errorf("could not find Manifest for %q", "gcr.io/nonsense-staging"),
 		},
 	}

--- a/internal/legacy/audit/auditor.go
+++ b/internal/legacy/audit/auditor.go
@@ -369,8 +369,8 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 func GetMatchingSourceRegistries(
 	manifests *[]manifest.Manifest,
 	gcrPayload *reg.GCRPubSubPayload,
-) ([]registry.RegistryContext, error) {
-	rcs := []registry.RegistryContext{}
+) ([]registry.Context, error) {
+	rcs := []registry.Context{}
 
 	for _, manifest := range *manifests {
 		if !gcrPayload.Match(&manifest).PathMatch {

--- a/internal/legacy/audit/auditor.go
+++ b/internal/legacy/audit/auditor.go
@@ -29,6 +29,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/logclient"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/remotemanifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/report"
@@ -365,10 +367,10 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 // GetMatchingSourceRegistries gets the first source repository that matches the
 // image information inside a GCRPubSubPayload.
 func GetMatchingSourceRegistries(
-	manifests *[]reg.Manifest,
+	manifests *[]manifest.Manifest,
 	gcrPayload *reg.GCRPubSubPayload,
-) ([]reg.RegistryContext, error) {
-	rcs := []reg.RegistryContext{}
+) ([]registry.RegistryContext, error) {
+	rcs := []registry.RegistryContext{}
 
 	for _, manifest := range *manifests {
 		if !gcrPayload.Match(&manifest).PathMatch {

--- a/internal/legacy/audit/auditor.go
+++ b/internal/legacy/audit/auditor.go
@@ -29,8 +29,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/logclient"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/remotemanifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/report"
@@ -367,7 +367,7 @@ func (s *ServerContext) Audit(w http.ResponseWriter, r *http.Request) {
 // GetMatchingSourceRegistries gets the first source repository that matches the
 // image information inside a GCRPubSubPayload.
 func GetMatchingSourceRegistries(
-	manifests *[]manifest.Manifest,
+	manifests *[]schema.Manifest,
 	gcrPayload *reg.GCRPubSubPayload,
 ) ([]registry.Context, error) {
 	rcs := []registry.Context{}

--- a/internal/legacy/audit/auditor_test.go
+++ b/internal/legacy/audit/auditor_test.go
@@ -182,7 +182,7 @@ func TestAudit(t *testing.T) {
 	// https://github.com/kubernetes-sigs/promo-tools/issues/191.
 	manifests1 := []manifest.Manifest{
 		{
-			Registries: []registry.RegistryContext{
+			Registries: []registry.Context{
 				{
 					Name: "gcr.io/k8s-staging-kas-network-proxy",
 					Src:  true,
@@ -339,7 +339,7 @@ func TestAudit(t *testing.T) {
 	// 3.4.7-2).
 	manifests2 := []manifest.Manifest{
 		{
-			Registries: []registry.RegistryContext{
+			Registries: []registry.Context{
 				{
 					Name: "gcr.io/google-containers",
 					Src:  true,
@@ -361,7 +361,7 @@ func TestAudit(t *testing.T) {
 			},
 		},
 		{
-			Registries: []registry.RegistryContext{
+			Registries: []registry.Context{
 				{
 					Name: "gcr.io/k8s-staging-etcd",
 					Src:  true,
@@ -848,7 +848,7 @@ func TestAudit(t *testing.T) {
 		// fakeReadRepo closes over "test" in the outer scope, as a closure
 		// should).
 		test := test
-		fakeReadRepo := func(sc *reg.SyncContext, rc registry.RegistryContext) stream.Producer {
+		fakeReadRepo := func(sc *reg.SyncContext, rc registry.Context) stream.Producer {
 			var sr stream.Fake
 
 			_, domain, repoPath := reg.GetTokenKeyDomainRepoPath(rc.Name)
@@ -943,7 +943,7 @@ func initFakeServerContext(
 	manifests []manifest.Manifest,
 	reportingFacility report.ReportingFacility,
 	loggingFacility logclient.LoggingFacility,
-	fakeReadRepo func(*reg.SyncContext, registry.RegistryContext) stream.Producer,
+	fakeReadRepo func(*reg.SyncContext, registry.Context) stream.Producer,
 	fakeReadManifestList func(*reg.SyncContext, *reg.GCRManifestListContext) stream.Producer,
 ) audit.ServerContext {
 	remoteManifestFacility := remotemanifest.NewFake(manifests)

--- a/internal/legacy/audit/auditor_test.go
+++ b/internal/legacy/audit/auditor_test.go
@@ -29,6 +29,8 @@ import (
 
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/audit"
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/logclient"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/remotemanifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/report"
@@ -178,9 +180,9 @@ func TestValidatePayload(t *testing.T) {
 func TestAudit(t *testing.T) {
 	// Regression test case for
 	// https://github.com/kubernetes-sigs/promo-tools/issues/191.
-	manifests1 := []reg.Manifest{
+	manifests1 := []manifest.Manifest{
 		{
-			Registries: []reg.RegistryContext{
+			Registries: []registry.RegistryContext{
 				{
 					Name: "gcr.io/k8s-staging-kas-network-proxy",
 					Src:  true,
@@ -191,10 +193,10 @@ func TestAudit(t *testing.T) {
 				},
 			},
 
-			Images: []reg.Image{
+			Images: []registry.Image{
 				{
 					Name: "proxy-agent",
-					Dmap: reg.DigestTags{
+					Dmap: registry.DigestTags{
 						"sha256:c419394f3fa40c32352be5a6ec5865270376d4351a3756bb1893be3f28fcba32": {"v0.0.8"},
 					},
 				},
@@ -335,9 +337,9 @@ func TestAudit(t *testing.T) {
 	// "us.gcr.io/k8s-artifacts-prod" (because both manifests below promote to
 	// that same destination, but only one of them have the child images of
 	// 3.4.7-2).
-	manifests2 := []reg.Manifest{
+	manifests2 := []manifest.Manifest{
 		{
-			Registries: []reg.RegistryContext{
+			Registries: []registry.RegistryContext{
 				{
 					Name: "gcr.io/google-containers",
 					Src:  true,
@@ -349,17 +351,17 @@ func TestAudit(t *testing.T) {
 				},
 			},
 
-			Images: []reg.Image{
+			Images: []registry.Image{
 				{
 					Name: "etcd",
-					Dmap: reg.DigestTags{
+					Dmap: registry.DigestTags{
 						"sha256:12f377200949c25fde1e54bba639d34d119edd7cfcfb1d117526dba677c03c85": {"3.4.7", "3.4.7-0"},
 					},
 				},
 			},
 		},
 		{
-			Registries: []reg.RegistryContext{
+			Registries: []registry.RegistryContext{
 				{
 					Name: "gcr.io/k8s-staging-etcd",
 					Src:  true,
@@ -376,10 +378,10 @@ func TestAudit(t *testing.T) {
 				},
 			},
 
-			Images: []reg.Image{
+			Images: []registry.Image{
 				{
 					Name: "etcd",
-					Dmap: reg.DigestTags{
+					Dmap: registry.DigestTags{
 						"sha256:bcdd5657b1edc1a2eb27356f33dd66b9400d4a084209c33461c7a7da0a32ebb3": {"3.4.7-2"},
 					},
 				},
@@ -640,7 +642,7 @@ func TestAudit(t *testing.T) {
 
 	shouldBeValid := []struct {
 		name             string
-		manifests        []reg.Manifest
+		manifests        []manifest.Manifest
 		payload          reg.GCRPubSubPayload
 		readRepo         map[string]string
 		readManifestList map[string]string
@@ -846,7 +848,7 @@ func TestAudit(t *testing.T) {
 		// fakeReadRepo closes over "test" in the outer scope, as a closure
 		// should).
 		test := test
-		fakeReadRepo := func(sc *reg.SyncContext, rc reg.RegistryContext) stream.Producer {
+		fakeReadRepo := func(sc *reg.SyncContext, rc registry.RegistryContext) stream.Producer {
 			var sr stream.Fake
 
 			_, domain, repoPath := reg.GetTokenKeyDomainRepoPath(rc.Name)
@@ -938,10 +940,10 @@ func TestAudit(t *testing.T) {
 }
 
 func initFakeServerContext(
-	manifests []reg.Manifest,
+	manifests []manifest.Manifest,
 	reportingFacility report.ReportingFacility,
 	loggingFacility logclient.LoggingFacility,
-	fakeReadRepo func(*reg.SyncContext, reg.RegistryContext) stream.Producer,
+	fakeReadRepo func(*reg.SyncContext, registry.RegistryContext) stream.Producer,
 	fakeReadManifestList func(*reg.SyncContext, *reg.GCRManifestListContext) stream.Producer,
 ) audit.ServerContext {
 	remoteManifestFacility := remotemanifest.NewFake(manifests)

--- a/internal/legacy/audit/auditor_test.go
+++ b/internal/legacy/audit/auditor_test.go
@@ -29,8 +29,8 @@ import (
 
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/audit"
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/logclient"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/remotemanifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/report"
@@ -180,7 +180,7 @@ func TestValidatePayload(t *testing.T) {
 func TestAudit(t *testing.T) {
 	// Regression test case for
 	// https://github.com/kubernetes-sigs/promo-tools/issues/191.
-	manifests1 := []manifest.Manifest{
+	manifests1 := []schema.Manifest{
 		{
 			Registries: []registry.Context{
 				{
@@ -337,7 +337,7 @@ func TestAudit(t *testing.T) {
 	// "us.gcr.io/k8s-artifacts-prod" (because both manifests below promote to
 	// that same destination, but only one of them have the child images of
 	// 3.4.7-2).
-	manifests2 := []manifest.Manifest{
+	manifests2 := []schema.Manifest{
 		{
 			Registries: []registry.Context{
 				{
@@ -642,7 +642,7 @@ func TestAudit(t *testing.T) {
 
 	shouldBeValid := []struct {
 		name             string
-		manifests        []manifest.Manifest
+		manifests        []schema.Manifest
 		payload          reg.GCRPubSubPayload
 		readRepo         map[string]string
 		readManifestList map[string]string
@@ -940,7 +940,7 @@ func TestAudit(t *testing.T) {
 }
 
 func initFakeServerContext(
-	manifests []manifest.Manifest,
+	manifests []schema.Manifest,
 	reportingFacility report.ReportingFacility,
 	loggingFacility logclient.LoggingFacility,
 	fakeReadRepo func(*reg.SyncContext, registry.Context) stream.Producer,

--- a/internal/legacy/audit/types.go
+++ b/internal/legacy/audit/types.go
@@ -18,6 +18,7 @@ package audit
 
 import (
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/logclient"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/remotemanifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/report"
@@ -27,7 +28,7 @@ import (
 // GcrReadingFacility holds functions used to create streams for reading the
 // repository and manifest list.
 type GcrReadingFacility struct {
-	ReadRepo         func(*reg.SyncContext, reg.RegistryContext) stream.Producer
+	ReadRepo         func(*reg.SyncContext, registry.RegistryContext) stream.Producer
 	ReadManifestList func(*reg.SyncContext, *reg.GCRManifestListContext) stream.Producer
 }
 

--- a/internal/legacy/audit/types.go
+++ b/internal/legacy/audit/types.go
@@ -28,7 +28,7 @@ import (
 // GcrReadingFacility holds functions used to create streams for reading the
 // repository and manifest list.
 type GcrReadingFacility struct {
-	ReadRepo         func(*reg.SyncContext, registry.RegistryContext) stream.Producer
+	ReadRepo         func(*reg.SyncContext, registry.Context) stream.Producer
 	ReadManifestList func(*reg.SyncContext, *reg.GCRManifestListContext) stream.Producer
 }
 

--- a/internal/legacy/dockerregistry/checks.go
+++ b/internal/legacy/dockerregistry/checks.go
@@ -31,6 +31,7 @@ import (
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 	gogit "gopkg.in/src-d/go-git.v4"
 
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 )
 
@@ -117,7 +118,7 @@ func (check *ImageRemovalCheck) Run() error {
 			" repo: %v", err)
 	}
 
-	mfests, err := ParseThinManifestsFromDir(check.GitRepoPath)
+	mfests, err := manifest.ParseThinManifestsFromDir(check.GitRepoPath)
 	if err != nil {
 		return fmt.Errorf("could not parse manifests from the directory: %v",
 			err)

--- a/internal/legacy/dockerregistry/checks.go
+++ b/internal/legacy/dockerregistry/checks.go
@@ -31,7 +31,7 @@ import (
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 	gogit "gopkg.in/src-d/go-git.v4"
 
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 )
 
@@ -118,7 +118,7 @@ func (check *ImageRemovalCheck) Run() error {
 			" repo: %v", err)
 	}
 
-	mfests, err := manifest.ParseThinManifestsFromDir(check.GitRepoPath)
+	mfests, err := schema.ParseThinManifestsFromDir(check.GitRepoPath)
 	if err != nil {
 		return fmt.Errorf("could not parse manifests from the directory: %v",
 			err)

--- a/internal/legacy/dockerregistry/checks_test.go
+++ b/internal/legacy/dockerregistry/checks_test.go
@@ -24,8 +24,8 @@ import (
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
 
@@ -74,21 +74,21 @@ func TestImageRemovalCheck(t *testing.T) {
 	tests := []struct {
 		name            string
 		check           reg.ImageRemovalCheck
-		masterManifests []manifest.Manifest
-		pullManifests   []manifest.Manifest
+		masterManifests []schema.Manifest
+		pullManifests   []schema.Manifest
 		expected        error
 	}{
 		{
 			"Empty manifests",
 			reg.ImageRemovalCheck{},
-			[]manifest.Manifest{},
-			[]manifest.Manifest{},
+			[]schema.Manifest{},
+			[]schema.Manifest{},
 			nil,
 		},
 		{
 			"Same manifests",
 			reg.ImageRemovalCheck{},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -97,7 +97,7 @@ func TestImageRemovalCheck(t *testing.T) {
 					SrcRegistry: &srcRC,
 				},
 			},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -111,7 +111,7 @@ func TestImageRemovalCheck(t *testing.T) {
 		{
 			"Different manifests",
 			reg.ImageRemovalCheck{},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -120,7 +120,7 @@ func TestImageRemovalCheck(t *testing.T) {
 					SrcRegistry: &srcRC,
 				},
 			},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -136,7 +136,7 @@ func TestImageRemovalCheck(t *testing.T) {
 		{
 			"Promoting same image from different registry",
 			reg.ImageRemovalCheck{},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries2,
 					Images: []registry.Image{
@@ -145,7 +145,7 @@ func TestImageRemovalCheck(t *testing.T) {
 					SrcRegistry: &srcRC,
 				},
 			},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries2,
 					Images: []registry.Image{
@@ -159,7 +159,7 @@ func TestImageRemovalCheck(t *testing.T) {
 		{
 			"Promoting image with same name and different digest",
 			reg.ImageRemovalCheck{},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -168,7 +168,7 @@ func TestImageRemovalCheck(t *testing.T) {
 					SrcRegistry: &srcRC,
 				},
 			},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -228,7 +228,7 @@ func TestImageSizeCheck(t *testing.T) {
 	tests := []struct {
 		name       string
 		check      reg.ImageSizeCheck
-		manifests  []manifest.Manifest
+		manifests  []schema.Manifest
 		imageSizes map[image.Digest]int
 		expected   error
 	}{
@@ -238,7 +238,7 @@ func TestImageSizeCheck(t *testing.T) {
 				MaxImageSize:    1,
 				DigestImageSize: make(reg.DigestImageSize),
 			},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -258,7 +258,7 @@ func TestImageSizeCheck(t *testing.T) {
 				MaxImageSize:    1,
 				DigestImageSize: make(reg.DigestImageSize),
 			},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -284,7 +284,7 @@ func TestImageSizeCheck(t *testing.T) {
 				MaxImageSize:    1,
 				DigestImageSize: make(reg.DigestImageSize),
 			},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{
@@ -313,7 +313,7 @@ func TestImageSizeCheck(t *testing.T) {
 				MaxImageSize:    1,
 				DigestImageSize: make(reg.DigestImageSize),
 			},
-			[]manifest.Manifest{
+			[]schema.Manifest{
 				{
 					Registries: registries,
 					Images: []registry.Image{

--- a/internal/legacy/dockerregistry/checks_test.go
+++ b/internal/legacy/dockerregistry/checks_test.go
@@ -24,6 +24,8 @@ import (
 	grafeaspb "google.golang.org/genproto/googleapis/grafeas/v1"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
 
@@ -31,40 +33,40 @@ func TestImageRemovalCheck(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/foo")
 	srcRegName2 := image.Registry("gcr.io/foo2")
 	destRegName := image.Registry("gcr.io/bar")
-	destRC := reg.RegistryContext{
+	destRC := registry.RegistryContext{
 		Name:           destRegName,
 		ServiceAccount: "robot",
 	}
-	srcRC := reg.RegistryContext{
+	srcRC := registry.RegistryContext{
 		Name:           srcRegName,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
-	srcRC2 := reg.RegistryContext{
+	srcRC2 := registry.RegistryContext{
 		Name:           srcRegName2,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
-	registries := []reg.RegistryContext{destRC, srcRC}
-	registries2 := []reg.RegistryContext{destRC, srcRC, srcRC2}
+	registries := []registry.RegistryContext{destRC, srcRC}
+	registries2 := []registry.RegistryContext{destRC, srcRC, srcRC2}
 
-	imageA := reg.Image{
+	imageA := registry.Image{
 		Name: "a",
-		Dmap: reg.DigestTags{
+		Dmap: registry.DigestTags{
 			"sha256:000": {"0.9"},
 		},
 	}
 
-	imageA2 := reg.Image{
+	imageA2 := registry.Image{
 		Name: "a",
-		Dmap: reg.DigestTags{
+		Dmap: registry.DigestTags{
 			"sha256:111": {"0.9"},
 		},
 	}
 
-	imageB := reg.Image{
+	imageB := registry.Image{
 		Name: "b",
-		Dmap: reg.DigestTags{
+		Dmap: registry.DigestTags{
 			"sha256:000": {"0.9"},
 		},
 	}
@@ -72,33 +74,33 @@ func TestImageRemovalCheck(t *testing.T) {
 	tests := []struct {
 		name            string
 		check           reg.ImageRemovalCheck
-		masterManifests []reg.Manifest
-		pullManifests   []reg.Manifest
+		masterManifests []manifest.Manifest
+		pullManifests   []manifest.Manifest
 		expected        error
 	}{
 		{
 			"Empty manifests",
 			reg.ImageRemovalCheck{},
-			[]reg.Manifest{},
-			[]reg.Manifest{},
+			[]manifest.Manifest{},
+			[]manifest.Manifest{},
 			nil,
 		},
 		{
 			"Same manifests",
 			reg.ImageRemovalCheck{},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						imageA,
 					},
 					SrcRegistry: &srcRC,
 				},
 			},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						imageA,
 					},
 					SrcRegistry: &srcRC,
@@ -109,19 +111,19 @@ func TestImageRemovalCheck(t *testing.T) {
 		{
 			"Different manifests",
 			reg.ImageRemovalCheck{},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						imageA,
 					},
 					SrcRegistry: &srcRC,
 				},
 			},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						imageB,
 					},
 					SrcRegistry: &srcRC,
@@ -134,19 +136,19 @@ func TestImageRemovalCheck(t *testing.T) {
 		{
 			"Promoting same image from different registry",
 			reg.ImageRemovalCheck{},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries2,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						imageA,
 					},
 					SrcRegistry: &srcRC,
 				},
 			},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries2,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						imageA,
 					},
 					SrcRegistry: &srcRC2,
@@ -157,19 +159,19 @@ func TestImageRemovalCheck(t *testing.T) {
 		{
 			"Promoting image with same name and different digest",
 			reg.ImageRemovalCheck{},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						imageA,
 					},
 					SrcRegistry: &srcRC,
 				},
 			},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						imageA2,
 					},
 					SrcRegistry: &srcRC,
@@ -197,28 +199,28 @@ func TestImageSizeCheck(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/foo")
 	destRegName := image.Registry("gcr.io/bar")
 
-	destRC := reg.RegistryContext{
+	destRC := registry.RegistryContext{
 		Name:           destRegName,
 		ServiceAccount: "robot",
 	}
 
-	srcRC := reg.RegistryContext{
+	srcRC := registry.RegistryContext{
 		Name:           srcRegName,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
 
-	registries := []reg.RegistryContext{destRC, srcRC}
+	registries := []registry.RegistryContext{destRC, srcRC}
 
-	image1 := reg.Image{
+	image1 := registry.Image{
 		Name: "foo",
-		Dmap: reg.DigestTags{
+		Dmap: registry.DigestTags{
 			"sha256:000": {"0.9"},
 		},
 	}
-	image2 := reg.Image{
+	image2 := registry.Image{
 		Name: "bar",
-		Dmap: reg.DigestTags{
+		Dmap: registry.DigestTags{
 			"sha256:111": {"0.9"},
 		},
 	}
@@ -226,7 +228,7 @@ func TestImageSizeCheck(t *testing.T) {
 	tests := []struct {
 		name       string
 		check      reg.ImageSizeCheck
-		manifests  []reg.Manifest
+		manifests  []manifest.Manifest
 		imageSizes map[image.Digest]int
 		expected   error
 	}{
@@ -236,10 +238,10 @@ func TestImageSizeCheck(t *testing.T) {
 				MaxImageSize:    1,
 				DigestImageSize: make(reg.DigestImageSize),
 			},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						image1,
 					},
 					SrcRegistry: &srcRC,
@@ -256,10 +258,10 @@ func TestImageSizeCheck(t *testing.T) {
 				MaxImageSize:    1,
 				DigestImageSize: make(reg.DigestImageSize),
 			},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						image1,
 					},
 					SrcRegistry: &srcRC,
@@ -282,10 +284,10 @@ func TestImageSizeCheck(t *testing.T) {
 				MaxImageSize:    1,
 				DigestImageSize: make(reg.DigestImageSize),
 			},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						image1,
 						image2,
 					},
@@ -311,10 +313,10 @@ func TestImageSizeCheck(t *testing.T) {
 				MaxImageSize:    1,
 				DigestImageSize: make(reg.DigestImageSize),
 			},
-			[]reg.Manifest{
+			[]manifest.Manifest{
 				{
 					Registries: registries,
-					Images: []reg.Image{
+					Images: []registry.Image{
 						image1,
 						image2,
 					},

--- a/internal/legacy/dockerregistry/checks_test.go
+++ b/internal/legacy/dockerregistry/checks_test.go
@@ -33,22 +33,22 @@ func TestImageRemovalCheck(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/foo")
 	srcRegName2 := image.Registry("gcr.io/foo2")
 	destRegName := image.Registry("gcr.io/bar")
-	destRC := registry.RegistryContext{
+	destRC := registry.Context{
 		Name:           destRegName,
 		ServiceAccount: "robot",
 	}
-	srcRC := registry.RegistryContext{
+	srcRC := registry.Context{
 		Name:           srcRegName,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
-	srcRC2 := registry.RegistryContext{
+	srcRC2 := registry.Context{
 		Name:           srcRegName2,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
-	registries := []registry.RegistryContext{destRC, srcRC}
-	registries2 := []registry.RegistryContext{destRC, srcRC, srcRC2}
+	registries := []registry.Context{destRC, srcRC}
+	registries2 := []registry.Context{destRC, srcRC, srcRC2}
 
 	imageA := registry.Image{
 		Name: "a",
@@ -199,18 +199,18 @@ func TestImageSizeCheck(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/foo")
 	destRegName := image.Registry("gcr.io/bar")
 
-	destRC := registry.RegistryContext{
+	destRC := registry.Context{
 		Name:           destRegName,
 		ServiceAccount: "robot",
 	}
 
-	srcRC := registry.RegistryContext{
+	srcRC := registry.Context{
 		Name:           srcRegName,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
 
-	registries := []registry.RegistryContext{destRC, srcRC}
+	registries := []registry.Context{destRC, srcRC}
 
 	image1 := registry.Image{
 		Name: "foo",

--- a/internal/legacy/dockerregistry/inventory.go
+++ b/internal/legacy/dockerregistry/inventory.go
@@ -40,8 +40,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/gcloud"
 	cipJson "sigs.k8s.io/promo-tools/v3/internal/legacy/json"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/reqcounter"
@@ -51,7 +51,7 @@ import (
 
 // MakeSyncContext creates a SyncContext.
 func MakeSyncContext(
-	mfests []manifest.Manifest,
+	mfests []schema.Manifest,
 	threads int,
 	confirm, useSvcAcc bool,
 ) (SyncContext, error) {
@@ -123,7 +123,7 @@ func (sc *SyncContext) LogJSONSummary() {
 
 // ToPromotionEdges converts a list of manifests to a set of edges we want to
 // try promoting.
-func ToPromotionEdges(mfests []manifest.Manifest) (map[PromotionEdge]interface{}, error) {
+func ToPromotionEdges(mfests []schema.Manifest) (map[PromotionEdge]interface{}, error) {
 	edges := make(map[PromotionEdge]interface{})
 	for _, mfest := range mfests {
 		for _, img := range mfest.Images {
@@ -1840,7 +1840,7 @@ func MkRequestCapturer(captured *CapturedRequests) ProcessRequest {
 
 // GarbageCollect deletes all images that are not referenced by Docker tags.
 func (sc *SyncContext) GarbageCollect(
-	mfest manifest.Manifest,
+	mfest schema.Manifest,
 	mkProducer func(registry.Context, image.Name, image.Digest) stream.Producer,
 	customProcessRequest *ProcessRequest,
 ) {
@@ -2171,7 +2171,7 @@ type GcrPayloadMatch struct {
 
 // Match checks whether a GCRPubSubPayload is mentioned in a Manifest. The
 // degree of the match is reflected in the GcrPayloadMatch result.
-func (payload *GCRPubSubPayload) Match(mfest *manifest.Manifest) GcrPayloadMatch {
+func (payload *GCRPubSubPayload) Match(mfest *schema.Manifest) GcrPayloadMatch {
 	var m GcrPayloadMatch
 	for _, rc := range mfest.Registries {
 		m = payload.matchImages(&rc, mfest.Images)

--- a/internal/legacy/dockerregistry/inventory_test.go
+++ b/internal/legacy/dockerregistry/inventory_test.go
@@ -140,7 +140,7 @@ func TestParseRegistryManifest(t *testing.T) {
 images: []
 `,
 			manifest.Manifest{
-				Registries: []registry.RegistryContext{
+				Registries: []registry.Context{
 					{
 						Name:           "gcr.io/bar",
 						ServiceAccount: "foobar@google-containers.iam.gserviceaccount.com",
@@ -173,7 +173,7 @@ images:
     "sha256:07353f7b26327f0d933515a22b1de587b040d3d85c464ea299c1b9f242529326": [ "1.8.3" ]  # Branches: ['master']
 `,
 			manifest.Manifest{
-				Registries: []registry.RegistryContext{
+				Registries: []registry.Context{
 					{
 						Name:           "gcr.io/bar",
 						ServiceAccount: "foobar@google-containers.iam.gserviceaccount.com",
@@ -267,7 +267,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 			"singleton",
 			[]manifest.Manifest{
 				{
-					Registries: []registry.RegistryContext{
+					Registries: []registry.Context{
 						{
 							Name:           "gcr.io/foo-staging",
 							ServiceAccount: "sa@robot.com",
@@ -304,7 +304,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 			"multiple-rebases",
 			[]manifest.Manifest{
 				{
-					Registries: []registry.RegistryContext{
+					Registries: []registry.Context{
 						{
 							Name:           "gcr.io/foo-staging",
 							ServiceAccount: "sa@robot.com",
@@ -334,7 +334,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 					Filepath: "manifests/a/promoter-manifest.yaml",
 				},
 				{
-					Registries: []registry.RegistryContext{
+					Registries: []registry.Context{
 						{
 							Name:           "gcr.io/bar-staging",
 							ServiceAccount: "sa@robot.com",
@@ -371,7 +371,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 			"basic-thin",
 			[]manifest.Manifest{
 				{
-					Registries: []registry.RegistryContext{
+					Registries: []registry.Context{
 						{
 							Name:           "gcr.io/foo-staging",
 							ServiceAccount: "sa@robot.com",
@@ -401,7 +401,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 					Filepath: "manifests/a/promoter-manifest.yaml",
 				},
 				{
-					Registries: []registry.RegistryContext{
+					Registries: []registry.Context{
 						{
 							Name:           "gcr.io/bar-staging",
 							ServiceAccount: "sa@robot.com",
@@ -431,7 +431,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 					Filepath: "manifests/b/promoter-manifest.yaml",
 				},
 				{
-					Registries: []registry.RegistryContext{
+					Registries: []registry.Context{
 						{
 							Name:           "gcr.io/cat-staging",
 							ServiceAccount: "sa@robot.com",
@@ -461,7 +461,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 					Filepath: "manifests/c/promoter-manifest.yaml",
 				},
 				{
-					Registries: []registry.RegistryContext{
+					Registries: []registry.Context{
 						{
 							Name:           "gcr.io/qux-staging",
 							ServiceAccount: "sa@robot.com",
@@ -798,9 +798,9 @@ func TestSplitByKnownRegistries(t *testing.T) {
 		`us.gcr.io/k8s-artifacts-prod/metrics-server`,
 		`us.gcr.io/k8s-artifacts-prod`,
 	}
-	knownRegistryContexts := make([]registry.RegistryContext, 0)
+	knownRegistryContexts := make([]registry.Context, 0)
 	for _, knownRegistryName := range knownRegistryNames {
-		rc := registry.RegistryContext{}
+		rc := registry.Context{}
 		rc.Name = knownRegistryName
 		knownRegistryContexts = append(knownRegistryContexts, rc)
 	}
@@ -836,7 +836,7 @@ func TestSplitByKnownRegistries(t *testing.T) {
 }
 
 func TestCommandGeneration(t *testing.T) {
-	destRC := registry.RegistryContext{
+	destRC := registry.Context{
 		Name:           "gcr.io/foo",
 		ServiceAccount: "robot",
 	}
@@ -1141,7 +1141,7 @@ func TestReadRegistries(t *testing.T) {
 	for _, test := range tests {
 		// Destination registry is a placeholder, because ReadImageNames acts on
 		// 2 registries (src and dest) at once.
-		rcs := []registry.RegistryContext{
+		rcs := []registry.Context{
 			{
 				Name:           fakeRegName,
 				ServiceAccount: "robot",
@@ -1158,7 +1158,7 @@ func TestReadRegistries(t *testing.T) {
 		// test is used to pin the "test" variable from the outer "range"
 		// scope (see scopelint).
 		test := test
-		mkFakeStream1 := func(sc *reg.SyncContext, rc registry.RegistryContext) stream.Producer {
+		mkFakeStream1 := func(sc *reg.SyncContext, rc registry.Context) stream.Producer {
 			var sr stream.Fake
 
 			_, domain, repoPath := reg.GetTokenKeyDomainRepoPath(rc.Name)
@@ -1223,7 +1223,7 @@ func TestReadGManifestLists(t *testing.T) {
 	for _, test := range tests {
 		// Destination registry is a placeholder, because ReadImageNames acts on
 		// 2 registries (src and dest) at once.
-		rcs := []registry.RegistryContext{
+		rcs := []registry.Context{
 			{
 				Name:           fakeRegName,
 				ServiceAccount: "robot",
@@ -1461,21 +1461,21 @@ func TestToPromotionEdges(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/foo")
 	destRegName := image.Registry("gcr.io/bar")
 	destRegName2 := image.Registry("gcr.io/cat")
-	destRC := registry.RegistryContext{
+	destRC := registry.Context{
 		Name:           destRegName,
 		ServiceAccount: "robot",
 	}
-	destRC2 := registry.RegistryContext{
+	destRC2 := registry.Context{
 		Name:           destRegName2,
 		ServiceAccount: "robot",
 	}
-	srcRC := registry.RegistryContext{
+	srcRC := registry.Context{
 		Name:           srcRegName,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
-	registries1 := []registry.RegistryContext{destRC, srcRC}
-	registries2 := []registry.RegistryContext{destRC, srcRC, destRC2}
+	registries1 := []registry.Context{destRC, srcRC}
+	registries2 := []registry.Context{destRC, srcRC, destRC2}
 
 	sc := reg.SyncContext{
 		Inv: reg.MasterInventory{
@@ -1700,11 +1700,11 @@ func TestToPromotionEdges(t *testing.T) {
 func TestCheckOverlappingEdges(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/foo")
 	destRegName := image.Registry("gcr.io/bar")
-	destRC := registry.RegistryContext{
+	destRC := registry.Context{
 		Name:           destRegName,
 		ServiceAccount: "robot",
 	}
-	srcRC := registry.RegistryContext{
+	srcRC := registry.Context{
 		Name:           srcRegName,
 		ServiceAccount: "robot",
 		Src:            true,
@@ -1983,22 +1983,22 @@ func TestPromotion(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/foo")
 	destRegName := image.Registry("gcr.io/bar")
 	destRegName2 := image.Registry("gcr.io/cat")
-	destRC := registry.RegistryContext{
+	destRC := registry.Context{
 		Name:           destRegName,
 		ServiceAccount: "robot",
 	}
-	destRC2 := registry.RegistryContext{
+	destRC2 := registry.Context{
 		Name:           destRegName2,
 		ServiceAccount: "robot",
 	}
-	srcRC := registry.RegistryContext{
+	srcRC := registry.Context{
 		Name:           srcRegName,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
-	registries := []registry.RegistryContext{destRC, srcRC, destRC2}
+	registries := []registry.Context{destRC, srcRC, destRC2}
 
-	registriesRebase := []registry.RegistryContext{
+	registriesRebase := []registry.Context{
 		{
 			Name:           image.Registry("us.gcr.io/dog/some/subdir/path/foo"),
 			ServiceAccount: "robot",
@@ -2530,7 +2530,7 @@ func TestPromotion(t *testing.T) {
 	nopStream := func(
 		srcRegistry image.Registry,
 		srcImageName image.Name,
-		rc registry.RegistryContext,
+		rc registry.Context,
 		destImageName image.Name,
 		digest image.Digest,
 		tag image.Tag,
@@ -2579,28 +2579,28 @@ func TestPromotion(t *testing.T) {
 func TestExecRequests(t *testing.T) {
 	sc := reg.SyncContext{}
 
-	destRC := registry.RegistryContext{
+	destRC := registry.Context{
 		Name:           image.Registry("gcr.io/bar"),
 		ServiceAccount: "robot",
 	}
 
-	destRC2 := registry.RegistryContext{
+	destRC2 := registry.Context{
 		Name:           image.Registry("gcr.io/cat"),
 		ServiceAccount: "robot",
 	}
 
-	srcRC := registry.RegistryContext{
+	srcRC := registry.Context{
 		Name:           image.Registry("gcr.io/foo"),
 		ServiceAccount: "robot",
 		Src:            true,
 	}
 
-	registries := []registry.RegistryContext{destRC, srcRC, destRC2}
+	registries := []registry.Context{destRC, srcRC, destRC2}
 
 	nopStream := func(
 		srcRegistry image.Registry,
 		srcImageName image.Name,
-		rc registry.RegistryContext,
+		rc registry.Context,
 		destImageName image.Name,
 		digest image.Digest,
 		tag image.Tag,
@@ -2690,17 +2690,17 @@ func TestExecRequests(t *testing.T) {
 func TestValidateEdges(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/src")
 	dstRegName := image.Registry("gcr.io/dst")
-	srcRegistry := registry.RegistryContext{
+	srcRegistry := registry.Context{
 		Name:           srcRegName,
 		ServiceAccount: "robot",
 		Src:            true,
 	}
-	dstRegistry := registry.RegistryContext{
+	dstRegistry := registry.Context{
 		Name:           dstRegName,
 		ServiceAccount: "robot",
 	}
 
-	registries := []registry.RegistryContext{
+	registries := []registry.Context{
 		srcRegistry,
 		dstRegistry,
 	}
@@ -2825,7 +2825,7 @@ func TestGarbageCollection(t *testing.T) {
 	srcRegName := image.Registry("gcr.io/foo")
 	destRegName := image.Registry("gcr.io/bar")
 	destRegName2 := image.Registry("gcr.io/cat")
-	registries := []registry.RegistryContext{
+	registries := []registry.Context{
 		{
 			Name:           srcRegName,
 			ServiceAccount: "robot",
@@ -2976,7 +2976,7 @@ func TestGarbageCollection(t *testing.T) {
 		// Reset captured for each test.
 		captured = make(reg.CapturedRequests)
 		nopStream := func(
-			destRC registry.RegistryContext,
+			destRC registry.Context,
 			imageName image.Name,
 			digest image.Digest) stream.Producer {
 			return nil
@@ -2996,23 +2996,23 @@ func TestGarbageCollectionMulti(t *testing.T) {
 	destRegName1 := image.Registry("gcr.io/dest1")
 	destRegName2 := image.Registry("gcr.io/dest2")
 
-	destRC := registry.RegistryContext{
+	destRC := registry.Context{
 		Name:           destRegName1,
 		ServiceAccount: "robotDest1",
 	}
 
-	destRC2 := registry.RegistryContext{
+	destRC2 := registry.Context{
 		Name:           destRegName2,
 		ServiceAccount: "robotDest2",
 	}
 
-	srcRC := registry.RegistryContext{
+	srcRC := registry.Context{
 		Name:           srcRegName,
 		ServiceAccount: "robotSrc",
 		Src:            true,
 	}
 
-	registries := []registry.RegistryContext{srcRC, destRC, destRC2}
+	registries := []registry.Context{srcRC, destRC, destRC2}
 	tests := []struct {
 		name         string
 		inputM       manifest.Manifest
@@ -3135,7 +3135,7 @@ func TestGarbageCollectionMulti(t *testing.T) {
 		// Reset captured for each test.
 		captured = make(reg.CapturedRequests)
 		nopStream := func(
-			destRC registry.RegistryContext,
+			destRC registry.Context,
 			imageName image.Name,
 			digest image.Digest,
 		) stream.Producer {
@@ -3234,9 +3234,9 @@ func TestParseContainerParts(t *testing.T) {
 	}
 
 	for _, test := range shouldBeValid {
-		registry, repository, err := reg.ParseContainerParts(test.input)
+		registryName, repository, err := reg.ParseContainerParts(test.input)
 		got := ContainerParts{
-			registry,
+			registryName,
 			repository,
 			err,
 		}
@@ -3305,9 +3305,9 @@ func TestParseContainerParts(t *testing.T) {
 	}
 
 	for _, test := range shouldBeInvalid {
-		registry, repository, err := reg.ParseContainerParts(test.input)
+		registryName, repository, err := reg.ParseContainerParts(test.input)
 		got := ContainerParts{
-			registry,
+			registryName,
 			repository,
 			err,
 		}
@@ -3318,7 +3318,7 @@ func TestParseContainerParts(t *testing.T) {
 
 func TestMatch(t *testing.T) {
 	inputMfest := manifest.Manifest{
-		Registries: []registry.RegistryContext{
+		Registries: []registry.Context{
 			{
 				Name:           "gcr.io/foo-staging",
 				ServiceAccount: "sa@robot.com",

--- a/internal/legacy/dockerregistry/manifest/manifest.go
+++ b/internal/legacy/dockerregistry/manifest/manifest.go
@@ -37,13 +37,13 @@ type Manifest struct {
 	// Registries contains the source and destination (Src/Dest) registry names.
 	// There must be at least 2 registries: 1 source registry and 1 or more
 	// destination registries.
-	Registries []registry.RegistryContext `yaml:"registries,omitempty"`
-	Images     []registry.Image           `yaml:"images,omitempty"`
+	Registries []registry.Context `yaml:"registries,omitempty"`
+	Images     []registry.Image   `yaml:"images,omitempty"`
 
 	// Hidden fields; these are data structure optimizations that are populated
 	// from the fields above. As they are redundant, there is no point in
 	// storing this information in YAML.
-	SrcRegistry *registry.RegistryContext
+	SrcRegistry *registry.Context
 	Filepath    string
 }
 
@@ -54,7 +54,7 @@ type Manifest struct {
 // Then, PRs modifying just the []Image YAML won't be able to modify the
 // src/destination repos or the credentials tied to them.
 type ThinManifest struct {
-	Registries []registry.RegistryContext `yaml:"registries,omitempty"`
+	Registries []registry.Context `yaml:"registries,omitempty"`
 	// Store actual image data somewhere else.
 	//
 	// NOTE: "ImagesPath" is deprecated. It does nothing and will be
@@ -227,8 +227,6 @@ func ValidateTag(tag image.Tag) error {
 }
 
 // Finalize finalizes a Manifest by populating extra fields.
-// TODO: ST1016: methods on the same type should have the same receiver name
-// nolint: stylecheck
 func (m *Manifest) Finalize() error {
 	// Perform semantic checks (beyond just YAML validation).
 	srcRegistry, err := registry.GetSrcRegistry(m.Registries)
@@ -241,9 +239,9 @@ func (m *Manifest) Finalize() error {
 }
 
 // ToRegInvImage converts a Manifest into a RegInvImage.
-func (manifest *Manifest) ToRegInvImage() registry.RegInvImage {
+func (m *Manifest) ToRegInvImage() registry.RegInvImage {
 	rii := make(registry.RegInvImage)
-	for _, img := range manifest.Images {
+	for _, img := range m.Images {
 		rii[img.Name] = img.Dmap
 	}
 	return rii

--- a/internal/legacy/dockerregistry/manifest/manifest.go
+++ b/internal/legacy/dockerregistry/manifest/manifest.go
@@ -1,0 +1,526 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/types/image"
+)
+
+// Manifest stores the information in a manifest file (describing the
+// desired state of a Docker Registry).
+type Manifest struct {
+	// Registries contains the source and destination (Src/Dest) registry names.
+	// There must be at least 2 registries: 1 source registry and 1 or more
+	// destination registries.
+	Registries []registry.RegistryContext `yaml:"registries,omitempty"`
+	Images     []registry.Image           `yaml:"images,omitempty"`
+
+	// Hidden fields; these are data structure optimizations that are populated
+	// from the fields above. As they are redundant, there is no point in
+	// storing this information in YAML.
+	SrcRegistry *registry.RegistryContext
+	Filepath    string
+}
+
+// ThinManifest is a more secure Manifest because it does not define the
+// Images[] directly, but moves it to a separate location. The idea is to define
+// a ThinManifest type as a YAML in one folder, and to define the []Image in
+// another folder, and to have far stricter ACLs for the ThinManifest type.
+// Then, PRs modifying just the []Image YAML won't be able to modify the
+// src/destination repos or the credentials tied to them.
+type ThinManifest struct {
+	Registries []registry.RegistryContext `yaml:"registries,omitempty"`
+	// Store actual image data somewhere else.
+	//
+	// NOTE: "ImagesPath" is deprecated. It does nothing and will be
+	// removed in a future release. The images are always stored in a
+	// directory structure as follows:
+	//
+	//       foo
+	//       ├── images
+	//       │   ├── a
+	//       │   │   └── images.yaml
+	//       │   ├── b
+	//       │   │   └── images.yaml
+	//       │   ├── c
+	//       │   │   └── images.yaml
+	//       │   └── d
+	//       │       └── images.yaml
+	//       └── manifests
+	//           ├── a
+	//           │   └── promoter-manifest.yaml
+	//           ├── b
+	//           │   └── promoter-manifest.yaml
+	//           ├── c
+	//           │   └── promoter-manifest.yaml
+	//           └── d
+	//               └── promoter-manifest.yaml
+	//
+	// where "foo" is the toplevel folder holding all thin manifsets.
+	// That is, every manifest must be bifurcated into 2 parts, the
+	// "image" and "manifest" part, and these parts must be stored
+	// separately.
+
+	ImagesPath string `yaml:"imagesPath,omitempty"`
+}
+
+const (
+	// ThinManifestDepth specifies the number of items in a path if we split the
+	// path into its parts, starting from the "topmost" folder given as an
+	// argument to -thin-manifest-dir. E.g., a well-formed path is something
+	// like:
+	//
+	//  ["", "manifests", "foo", "promoter-manifests.yaml"]
+	//
+	// . This is a result of some path handling/parsing logic in
+	// ValidateThinManifestDirectoryStructure().
+	ThinManifestDepth = 4
+)
+
+// Validate checks for semantic errors in the yaml fields (the structure of the
+// yaml is checked during unmarshaling).
+func (m Manifest) Validate() error {
+	if err := validateRequiredComponents(m); err != nil {
+		return err
+	}
+	return validateImages(m.Images)
+}
+
+func validateRequiredComponents(m Manifest) error {
+	// TODO: Should we return []error here instead?
+	errs := make([]string, 0)
+	srcRegistryName := image.Registry("")
+
+	if len(m.Registries) > 0 {
+		if m.srcRegistryCount() > 1 {
+			errs = append(errs, "cannot have more than 1 source registry")
+		}
+
+		srcRegistryName = m.srcRegistryName()
+		if len(srcRegistryName) == 0 {
+			errs = append(errs, "source registry must be set")
+		}
+	}
+
+	knownRegistries := make([]image.Registry, 0)
+	if len(m.Registries) == 0 {
+		errs = append(errs, "'registries' field cannot be empty")
+	}
+
+	for _, registry := range m.Registries {
+		if len(registry.Name) == 0 {
+			errs = append(
+				errs,
+				"registries: 'name' field cannot be empty",
+			)
+		}
+
+		// TODO(lint): SA4010: this result of append is never used, except maybe in other appends
+		//nolint:staticcheck
+		knownRegistries = append(knownRegistries, registry.Name)
+	}
+
+	for _, img := range m.Images {
+		if len(img.Name) == 0 {
+			errs = append(
+				errs,
+				"images: 'name' field cannot be empty",
+			)
+		}
+
+		if len(img.Dmap) == 0 {
+			errs = append(
+				errs,
+				"images: 'dmap' field cannot be empty",
+			)
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(strings.Join(errs, "\n"))
+}
+
+func (m Manifest) srcRegistryCount() int {
+	var count int
+	for _, registry := range m.Registries {
+		if registry.Src {
+			count++
+		}
+	}
+
+	return count
+}
+
+func (m Manifest) srcRegistryName() image.Registry {
+	for _, registry := range m.Registries {
+		if registry.Src {
+			return registry.Name
+		}
+	}
+
+	return image.Registry("")
+}
+
+func validateImages(images []registry.Image) error {
+	for _, image := range images {
+		for digest, tagSlice := range image.Dmap {
+			if err := ValidateDigest(digest); err != nil {
+				return err
+			}
+
+			for _, tag := range tagSlice {
+				if err := ValidateTag(tag); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateDigest validates the digest.
+func ValidateDigest(digest image.Digest) error {
+	validDigest := regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	if !validDigest.Match([]byte(digest)) {
+		return fmt.Errorf("invalid digest: %v", digest)
+	}
+
+	return nil
+}
+
+// ValidateTag validates the tag.
+func ValidateTag(tag image.Tag) error {
+	validTag := regexp.MustCompile(`^[\w][\w.-]{0,127}$`)
+	if !validTag.Match([]byte(tag)) {
+		return fmt.Errorf("invalid tag: %v", tag)
+	}
+
+	return nil
+}
+
+// Finalize finalizes a Manifest by populating extra fields.
+// TODO: ST1016: methods on the same type should have the same receiver name
+// nolint: stylecheck
+func (m *Manifest) Finalize() error {
+	// Perform semantic checks (beyond just YAML validation).
+	srcRegistry, err := registry.GetSrcRegistry(m.Registries)
+	if err != nil {
+		return err
+	}
+	m.SrcRegistry = srcRegistry
+
+	return nil
+}
+
+// ToRegInvImage converts a Manifest into a RegInvImage.
+func (manifest *Manifest) ToRegInvImage() registry.RegInvImage {
+	rii := make(registry.RegInvImage)
+	for _, img := range manifest.Images {
+		rii[img.Name] = img.Dmap
+	}
+	return rii
+}
+
+// Parsers
+
+// ParseThinManifestsFromDir parses all thin Manifest files within a directory.
+// We effectively have to create a map of manifests, keyed by the source
+// registry (there can only be 1 source registry).
+func ParseThinManifestsFromDir(
+	dir string,
+) ([]Manifest, error) {
+	mfests := make([]Manifest, 0)
+
+	// Check that the thin manifests dir follows a regular, predefined format.
+	// This is to ensure that there isn't any funny business going on around
+	// paths.
+	if err := ValidateThinManifestDirectoryStructure(dir); err != nil {
+		return mfests, err
+	}
+
+	var parseAsManifest filepath.WalkFunc = func(
+		path string,
+		info os.FileInfo,
+		err error,
+	) error {
+		if err != nil {
+			// Prevent panic in case of incoming errors accessing this path.
+			logrus.Errorf("failure accessing a path %q: %v\n", path, err)
+		}
+
+		// Skip directories (because they are not YAML files).
+		if info.IsDir() {
+			return nil
+		}
+
+		// First try to parse the path as a manifest file, which must be named
+		// "promoter-manifest.yaml". This restriction is in place to limit the
+		// scope of what is read in as a promoter manifest.
+		if filepath.Base(path) != "promoter-manifest.yaml" {
+			return nil
+		}
+
+		// If there are any files named "promoter-manifest.yaml", they must be
+		// inside a subfolder within "manifests/<dir>" --- any other paths are
+		// forbidden.
+		shortened := strings.TrimPrefix(path, dir)
+		shortenedList := strings.Split(shortened, "/")
+		if len(shortenedList) != ThinManifestDepth {
+			return fmt.Errorf("unexpected manifest path %q",
+				path)
+		}
+
+		mfest, errParse := ParseThinManifestFromFile(path)
+		if errParse != nil {
+			logrus.Errorf("could not parse manifest file '%s'\n", path)
+			return errParse
+		}
+
+		// Save successful parse result.
+		mfests = append(mfests, mfest)
+
+		return nil
+	}
+
+	// Only look at manifests starting with the "manifests" subfolder (no need
+	// to walk any other toplevel subfolder).
+	if err := filepath.Walk(filepath.Join(dir, "manifests"), parseAsManifest); err != nil {
+		return mfests, err
+	}
+
+	if len(mfests) == 0 {
+		return nil, fmt.Errorf("no manifests found in dir: %s", dir)
+	}
+
+	return mfests, nil
+}
+
+// ParseManifestFromFile parses a Manifest from a filepath.
+func ParseManifestFromFile(filePath string) (Manifest, error) {
+	var mfest Manifest
+	var empty Manifest
+
+	b, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return empty, err
+	}
+
+	mfest, err = ParseManifestYAML(b)
+	if err != nil {
+		return empty, err
+	}
+
+	mfest.Filepath = filePath
+
+	err = mfest.Finalize()
+	if err != nil {
+		return empty, err
+	}
+
+	return mfest, nil
+}
+
+// ParseThinManifestFromFile parses a ThinManifest from a filepath and generates
+// a Manifest.
+func ParseThinManifestFromFile(filePath string) (Manifest, error) {
+	var thinManifest ThinManifest
+	var mfest Manifest
+	var empty Manifest
+
+	b, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return empty, err
+	}
+
+	thinManifest, err = ParseThinManifestYAML(b)
+	if err != nil {
+		return empty, err
+	}
+
+	// Get directory name holding this thin manifest.
+	subProject := filepath.Base(filepath.Dir(filePath))
+	imagesPath := filepath.Join(filepath.Dir(filePath),
+		"../../images",
+		subProject,
+		"images.yaml")
+	images, err := ParseImagesFromFile(imagesPath)
+	if err != nil {
+		return empty, err
+	}
+
+	mfest.Filepath = filePath
+	mfest.Images = images
+	mfest.Registries = thinManifest.Registries
+
+	err = mfest.Finalize()
+	if err != nil {
+		return empty, err
+	}
+
+	return mfest, nil
+}
+
+// ParseManifestYAML parses a Manifest from a byteslice. This function is
+// separate from ParseManifestFromFile() so that it can be tested independently.
+func ParseManifestYAML(b []byte) (Manifest, error) {
+	var m Manifest
+	if err := yaml.UnmarshalStrict(b, &m); err != nil {
+		return m, err
+	}
+
+	return m, m.Validate()
+}
+
+// ParseThinManifestYAML parses a ThinManifest from a byteslice.
+func ParseThinManifestYAML(b []byte) (ThinManifest, error) {
+	var m ThinManifest
+	if err := yaml.UnmarshalStrict(b, &m); err != nil {
+		return m, err
+	}
+
+	return m, nil
+}
+
+// ParseImagesYAML parses Images from a byteslice.
+func ParseImagesYAML(b []byte) (registry.Images, error) {
+	var images registry.Images
+	if err := yaml.UnmarshalStrict(b, &images); err != nil {
+		return images, err
+	}
+
+	return images, nil
+}
+
+// ValidateThinManifestDirectoryStructure enforces a particular directory
+// structure for thin manifests. Most importantly, it requires that if a file
+// named "foo/manifests/bar/promoter-manifest.yaml" exists, that a corresponding
+// file named "foo/images/bar/promoter-manifest.yaml" must also exist.
+func ValidateThinManifestDirectoryStructure(
+	dir string,
+) error {
+	// First, enforce that there are directories named "images" and "manifests".
+	if err := validateIsDirectory(filepath.Join(dir, "images")); err != nil {
+		return err
+	}
+
+	manifestDir := filepath.Join(dir, "manifests")
+	if err := validateIsDirectory(manifestDir); err != nil {
+		return err
+	}
+
+	// For every subfolder in <dir>/manifests, ensure that a
+	// "promoter-manifest.yaml" file exists, and also that a corresponding file
+	// exists in the "images" folder.
+	files, err := ioutil.ReadDir(manifestDir)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("*looking at %q", dir)
+	for _, file := range files {
+		p, err := os.Stat(filepath.Join(manifestDir, file.Name()))
+		if err != nil {
+			return err
+		}
+
+		// Skip non-directory sub-paths.
+		if !p.IsDir() {
+			continue
+		}
+
+		// Search for a "promoter-manifest.yaml" file under this directory.
+		manifestInfo, err := os.Stat(
+			filepath.Join(manifestDir,
+				file.Name(),
+				"promoter-manifest.yaml"))
+		if err != nil {
+			logrus.Warningln(err)
+			continue
+		}
+		if !manifestInfo.Mode().IsRegular() {
+			logrus.Warnf("ignoring irregular file %q", manifestInfo)
+			continue
+		}
+
+		// "promoter-manifest.yaml" exists, so check for corresponding images
+		// file, which MUST exist. This is why we fail early if we detect an
+		// error here.
+		imagesPath := filepath.Join(dir,
+			"images",
+			file.Name(),
+			"images.yaml")
+		imagesInfo, err := os.Stat(imagesPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("corresponding file %q does not exist",
+					imagesPath)
+			}
+			return err
+		}
+
+		if !imagesInfo.Mode().IsRegular() {
+			return fmt.Errorf("corresponding file %q is not a regular file",
+				imagesPath)
+		}
+	}
+
+	return nil
+}
+
+// ParseImagesFromFile parses an Images type from a file.
+func ParseImagesFromFile(filePath string) (registry.Images, error) {
+	var images registry.Images
+	var empty registry.Images
+
+	b, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return empty, err
+	}
+
+	images, err = ParseImagesYAML(b)
+	if err != nil {
+		return empty, err
+	}
+
+	return images, nil
+}
+
+// validateIsDirectory returns nil if it does exist, otherwise a non-nil error.
+func validateIsDirectory(dir string) error {
+	p, err := os.Stat(filepath.Join(dir))
+	if err != nil {
+		return err
+	}
+	if !p.IsDir() {
+		return fmt.Errorf("%q is not a directory", dir)
+	}
+	return nil
+}

--- a/internal/legacy/dockerregistry/registry/context.go
+++ b/internal/legacy/dockerregistry/registry/context.go
@@ -23,9 +23,9 @@ import (
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
 
-// RegistryContext holds information about a registry, to be written in a
+// Context holds information about a registry, to be written in a
 // manifest file.
-type RegistryContext struct {
+type Context struct {
 	Name           image.Registry `yaml:"name,omitempty"`
 	ServiceAccount string         `yaml:"service-account,omitempty"`
 	Token          gcloud.Token   `yaml:"-"`
@@ -33,7 +33,7 @@ type RegistryContext struct {
 }
 
 // GetSrcRegistry gets the source registry.
-func GetSrcRegistry(rcs []RegistryContext) (*RegistryContext, error) {
+func GetSrcRegistry(rcs []Context) (*Context, error) {
 	for _, registry := range rcs {
 		registry := registry
 		if registry.Src {

--- a/internal/legacy/dockerregistry/registry/context.go
+++ b/internal/legacy/dockerregistry/registry/context.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/gcloud"
+	"sigs.k8s.io/promo-tools/v3/types/image"
+)
+
+// RegistryContext holds information about a registry, to be written in a
+// manifest file.
+type RegistryContext struct {
+	Name           image.Registry `yaml:"name,omitempty"`
+	ServiceAccount string         `yaml:"service-account,omitempty"`
+	Token          gcloud.Token   `yaml:"-"`
+	Src            bool           `yaml:"src,omitempty"`
+}
+
+// GetSrcRegistry gets the source registry.
+func GetSrcRegistry(rcs []RegistryContext) (*RegistryContext, error) {
+	for _, registry := range rcs {
+		registry := registry
+		if registry.Src {
+			return &registry, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find source registry")
+}

--- a/internal/legacy/dockerregistry/registry/registry.go
+++ b/internal/legacy/dockerregistry/registry/registry.go
@@ -27,6 +27,17 @@ import (
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
 
+// Image holds information about an image. It's like an "Object" in the OOP
+// sense, and holds all the information relating to a particular image that we
+// care about.
+type Image struct {
+	Name image.Name `yaml:"name"`
+	Dmap DigestTags `yaml:"dmap,omitempty"`
+}
+
+// Images is a slice of Image types.
+type Images []Image
+
 // A RegInvImage is a map containing all of the image names, and their
 // associated digest-to-tags mappings. It is the simplest view of a Docker
 // Registry, because the keys are just the image.Names (where each image.Name does

--- a/internal/legacy/dockerregistry/registry/registry.go
+++ b/internal/legacy/dockerregistry/registry/registry.go
@@ -1,0 +1,446 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+
+	"sigs.k8s.io/promo-tools/v3/types/image"
+)
+
+// A RegInvImage is a map containing all of the image names, and their
+// associated digest-to-tags mappings. It is the simplest view of a Docker
+// Registry, because the keys are just the image.Names (where each image.Name does
+// *not* include the registry name, because we already key this by the
+// RegistryName in MasterInventory).
+//
+// The image.Name is actually a path name, because it can be "foo/bar/baz", where
+// the image name is the string after the last slash (in this case, "baz").
+type RegInvImage map[image.Name]DigestTags
+
+// DigestTags is a map where each digest is associated with a TagSlice. It is
+// associated with a TagSlice because an image digest can have more than 1 tag
+// pointing to it, even within the same image name's namespace (tags are
+// namespaced by the image name).
+type DigestTags map[image.Digest]TagSlice
+
+// TagSlice is a slice of Tags.
+type TagSlice []image.Tag
+
+// TagSet is a set of Tags.
+type TagSet map[image.Tag]interface{}
+
+// ToYAML displays a RegInvImage as YAML, but with the map items sorted
+// alphabetically.
+func (rii *RegInvImage) ToYAML(o YamlMarshalingOpts) string {
+	images := rii.ToSorted()
+
+	var b strings.Builder
+	for _, image := range images {
+		fmt.Fprintf(&b, "- name: %s\n", image.Name)
+		fmt.Fprintf(&b, "  dmap:\n")
+		for _, digestEntry := range image.Digests {
+			if o.BareDigest {
+				fmt.Fprintf(&b, "    %s:", digestEntry.Hash)
+			} else {
+				fmt.Fprintf(&b, "    %q:", digestEntry.Hash)
+			}
+
+			switch len(digestEntry.Tags) {
+			case 0:
+				fmt.Fprintf(&b, " []\n")
+			default:
+				if o.SplitTagsOverMultipleLines {
+					fmt.Fprintf(&b, "\n")
+					for _, tag := range digestEntry.Tags {
+						fmt.Fprintf(&b, "    - %s\n", tag)
+					}
+				} else {
+					fmt.Fprintf(&b, " [")
+					for i, tag := range digestEntry.Tags {
+						if i == len(digestEntry.Tags)-1 {
+							fmt.Fprintf(&b, "%q", tag)
+						} else {
+							fmt.Fprintf(&b, "%q, ", tag)
+						}
+					}
+					fmt.Fprintf(&b, "]\n")
+				}
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// ToCSV is like ToYAML, but instead of printing things in an indented
+// format, it prints one image on each line as a CSV. If there is a tag pointing
+// to the image, then it is printed next to the image on the same line.
+//
+// Example:
+// a@sha256:0000000000000000000000000000000000000000000000000000000000000000,a:1.0
+// a@sha256:0000000000000000000000000000000000000000000000000000000000000000,a:latest
+// b@sha256:1111111111111111111111111111111111111111111111111111111111111111,-
+func (rii *RegInvImage) ToCSV() string {
+	images := rii.ToSorted()
+
+	var b strings.Builder
+	for _, image := range images {
+		for _, digestEntry := range image.Digests {
+			if len(digestEntry.Tags) > 0 {
+				for _, tag := range digestEntry.Tags {
+					fmt.Fprintf(&b, "%s@%s,%s:%s\n",
+						image.Name,
+						digestEntry.Hash,
+						image.Name,
+						tag)
+				}
+			} else {
+				fmt.Fprintf(&b, "%s@%s,-\n", image.Name, digestEntry.Hash)
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// ToSorted converts a RegInvImage type to a sorted structure.
+func (rii *RegInvImage) ToSorted() []ImageWithDigestSlice {
+	images := make([]ImageWithDigestSlice, 0)
+
+	for name, dmap := range *rii {
+		var digests []Digest
+		for k, v := range dmap {
+			var tags []string
+			for _, tag := range v {
+				tags = append(tags, string(tag))
+			}
+
+			sort.Strings(tags)
+
+			digests = append(digests, Digest{
+				Hash: string(k),
+				Tags: tags,
+			})
+		}
+		sort.Slice(digests, func(i, j int) bool {
+			return digests[i].Hash < digests[j].Hash
+		})
+
+		images = append(images, ImageWithDigestSlice{
+			Name:    string(name),
+			Digests: digests,
+		})
+	}
+
+	sort.Slice(images, func(i, j int) bool {
+		return images[i].Name < images[j].Name
+	})
+
+	return images
+}
+
+// ImageWithDigestSlice uses a slice of digests instead of a map, allowing its
+// contents to be sorted.
+type ImageWithDigestSlice struct {
+	Name    string
+	Digests []Digest
+}
+
+type Digest struct {
+	Hash string
+	Tags []string
+}
+
+// TODO: Review/optimize/de-dupe (https://github.com/kubernetes-sigs/promo-tools/pull/351)
+type ImageWithParentDigestSlice struct {
+	Name          string
+	parentDigests []parentDigest
+}
+
+// TODO: Review/optimize/de-dupe (https://github.com/kubernetes-sigs/promo-tools/pull/351)
+type parentDigest struct {
+	hash     string
+	children []string
+}
+
+// FilterParentImages filters the given ImageWithDigestSlice and only returns the images of
+// who contain manifest lists (aka: fat-manifests). This is determined by inspecting the
+// "mediaType" of every image manifest in the registry.
+//
+// TODO: Review/optimize/de-dupe (https://github.com/kubernetes-sigs/promo-tools/pull/351)
+func FilterParentImages(registry image.Registry, images *[]ImageWithDigestSlice) ([]ImageWithParentDigestSlice, error) {
+	// If an image is found to have this specific media type, it is a parent, and will be saved.
+	// All other images are not of interest.
+	mediaType := `"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json"`
+	results := make([]ImageWithParentDigestSlice, 0)
+
+	// Split the registry into prefix and postfix
+	// For example: "us.gcr.io/k8s-artifacts-prod/addon-builder"
+	// prefix: "us.gcr.io"
+	// postfix: "/k8s-artifacts-prod/addon-builder"
+	firstSlash := strings.IndexByte(string(registry), '/')
+	registryPrefix := registry[:firstSlash]
+	registryPostfix := registry[firstSlash:]
+
+	// This is the number of goroutines that will be making curl requests over every image digest.
+	numWorkers := runtime.NumCPU() * 2
+	wg := new(sync.WaitGroup)
+	signal := make(chan ImageWithParentDigestSlice, 500)
+
+	filterImage := func(img ImageWithDigestSlice, c chan ImageWithParentDigestSlice) {
+		defer wg.Done()
+		imageLocation := fmt.Sprintf("%s/%s", registryPostfix, img.Name)
+
+		// This is a standard endpoint all container registries must adopt. This will reveal
+		// information about the manifest for the particular image. The output is in JSON form,
+		// with a field "mediaType" that reveals if the given image is a parent image.
+		manifestEndpoint := fmt.Sprintf("https://%s/v2%s/manifests/", registryPrefix, imageLocation)
+		result := ImageWithParentDigestSlice{img.Name, []parentDigest{}}
+		for _, digest := range img.Digests {
+			var response string
+			numRetries := 8
+			imgEndpoint := manifestEndpoint + digest.Hash
+			for numRetries > 0 {
+				out, err := exec.Command("curl", imgEndpoint).Output()
+				if err == nil {
+					response = string(out)
+					break
+				}
+				fmt.Println("something went wrong...")
+				fmt.Println("curl response:", err)
+				fmt.Println("retrying,", imgEndpoint)
+				numRetries--
+			}
+
+			if response == "" {
+				fmt.Println("Could not reach endpoint:", imgEndpoint)
+				continue
+			}
+
+			if !strings.Contains(response, mediaType) {
+				continue
+			}
+
+			// A new parent has been found.
+			parent := parentDigest{
+				hash:     digest.Hash,
+				children: []string{},
+			}
+
+			// Parse all children by looking for digest fields within response.
+			children := strings.Split(response, "},")
+			for _, child := range children {
+				digestIdx := strings.LastIndex(child, `"digest":`)
+				if digestIdx != -1 {
+					childHash := child[digestIdx+11 : digestIdx+82]
+					parent.children = append(parent.children, childHash)
+				}
+			}
+
+			result.parentDigests = append(result.parentDigests, parent)
+		}
+
+		c <- result
+	}
+
+	fmt.Printf("Searching for parent images with %d workers...\n", numWorkers)
+	received := 0
+
+	// Engage all workers.
+	for i := 0; i < numWorkers; i++ {
+		img := (*images)[i]
+		go filterImage(img, signal)
+		wg.Add(1)
+	}
+
+	// When a worker finishes, create another.
+	for i := numWorkers; i < len(*images); i++ {
+		found := <-signal
+		received++
+		if len(found.parentDigests) > 0 {
+			results = append(results, found)
+			fmt.Println("FOUND parent:", found.Name)
+		}
+
+		img := (*images)[i]
+		go filterImage(img, signal)
+		wg.Add(1)
+	}
+
+	// Gather all results.
+	wg.Wait()
+	for found := range signal {
+		received++
+		if len(found.parentDigests) > 0 {
+			results = append(results, found)
+			fmt.Println("FOUND parent:", found.Name)
+		}
+
+		if received == len(*images) {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+// TODO: Review/optimize/de-dupe (https://github.com/kubernetes-sigs/promo-tools/pull/351)
+func ValidateParentImages(registry image.Registry, images []ImageWithParentDigestSlice) {
+	numWorkers := runtime.NumCPU() * 2
+	wg := new(sync.WaitGroup)
+	signal := make(chan string, 500)
+
+	validateImg := func(image ImageWithParentDigestSlice, c chan string) {
+		defer wg.Done()
+		if IsParentImageValid(registry, image) {
+			fmt.Println("PASSED - ", image.Name)
+			c <- ""
+			return
+		}
+
+		fmt.Println("FAILED - ", image.Name)
+		c <- image.Name
+	}
+
+	fmt.Printf("Inspecting children of %d parents...\n", len(images))
+	received := 0
+
+	// Engage all workers.
+	for i := 0; i < numWorkers; i++ {
+		img := images[i]
+		go validateImg(img, signal)
+		wg.Add(1)
+	}
+
+	// When a worker finishes, create another.
+	for i := numWorkers; i < len(images); i++ {
+		found := <-signal
+		received++
+		if len(found) > 0 {
+			fmt.Println("FAILED ", found)
+		}
+
+		img := images[i]
+		go validateImg(img, signal)
+		wg.Add(1)
+	}
+
+	// Gather all results.
+	wg.Wait()
+	for found := range signal {
+		received++
+		if len(found) > 0 {
+			fmt.Println("FAILED ", found)
+		}
+
+		if received == len(images) {
+			break
+		}
+	}
+}
+
+// IsParentImageValid only returns true if all child images, from the parent's
+// manifest list, are from the same image location.
+// Example:
+//		VALID 	parent=gcr.io/foo/bar child=gcr.io/foo/bar
+// 		INVALID parent=gcr.io/foo/bar child=gcr.io/foo/bar/foo
+//
+// TODO: Review/optimize/de-dupe (https://github.com/kubernetes-sigs/promo-tools/pull/351)
+func IsParentImageValid(registry image.Registry, img ImageWithParentDigestSlice) bool {
+	// Split the registry into prefix and postfix
+	// For example: "us.gcr.io/k8s-artifacts-prod/addon-builder"
+	// prefix: "us.gcr.io"
+	// postfix: "/k8s-artifacts-prod/addon-builder"
+	firstSlash := strings.IndexByte(string(registry), '/')
+	registryPrefix := registry[:firstSlash]
+	registryPostfix := registry[firstSlash:]
+
+	imageLocation := fmt.Sprintf("%s/%s", registryPostfix, img.Name)
+	manifestEndpoint := fmt.Sprintf("https://%s/v2%s/manifests/", registryPrefix, imageLocation)
+	for _, parent := range img.parentDigests {
+		for _, childHash := range parent.children {
+			var response string
+
+			// This is a standard endpoint all container registries must adopt. This will reveal
+			// information about the manifest for the particular image. The output is in JSON form,
+			// with a field "mediaType" that reveals if the given image is a parent image.
+			imgEndpoint := manifestEndpoint + childHash
+			retries := 8
+
+			// Inspect the image. If it doesn't exist, we know the parent child relationship
+			// can't be assumed.
+			for retries > 0 {
+				out, err := exec.Command("curl", imgEndpoint).Output()
+				if err == nil {
+					response = string(out)
+					break
+				}
+
+				fmt.Println("trouble obtaining child manifest...")
+				fmt.Println("curl response:", err)
+				fmt.Println("retrying ", imgEndpoint)
+				retries--
+			}
+
+			if retries == 0 {
+				fmt.Println("Failed to reach ", imgEndpoint)
+				fmt.Println("skipping...")
+				continue
+			}
+
+			if !strings.Contains(response, "mediaType") {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// YamlMarshalingOpts holds options for tweaking the YAML output.
+type YamlMarshalingOpts struct {
+	// Render multiple tags on separate lines. I.e.,
+	// prefer
+	//
+	//    sha256:abc...:
+	//    - one
+	//    - two
+	//
+	// over
+	//
+	//    sha256:abc...: ["one", "two"]
+	//
+	// If there is only 1 tag, it will be on one line in brackets (e.g.,
+	// '["one"]').
+	SplitTagsOverMultipleLines bool
+
+	// Do not quote the digest. I.e., prefer
+	//
+	//    sha256:...:
+	//
+	// over
+	//
+	//    "sha256:...":
+	//
+	BareDigest bool
+}

--- a/internal/legacy/dockerregistry/registry/set.go
+++ b/internal/legacy/dockerregistry/registry/set.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package inventory
+package registry
 
 import (
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/container"

--- a/internal/legacy/dockerregistry/schema/manifest.go
+++ b/internal/legacy/dockerregistry/schema/manifest.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package manifest
+package schema
 
 import (
 	"fmt"

--- a/internal/legacy/dockerregistry/types.go
+++ b/internal/legacy/dockerregistry/types.go
@@ -84,8 +84,8 @@ type SyncContext struct {
 	UseServiceAccount bool
 	Inv               MasterInventory
 	InvIgnore         []image.Name
-	RegistryContexts  []registry.RegistryContext
-	SrcRegistry       *registry.RegistryContext
+	RegistryContexts  []registry.Context
+	SrcRegistry       *registry.Context
 	Tokens            map[RootRepo]gcloud.Token
 	DigestMediaType   DigestMediaType
 	DigestImageSize   DigestImageSize
@@ -132,12 +132,12 @@ type ImageRemovalCheck struct {
 // PromotionEdge represents a promotion "link" of an image repository between 2
 // registries.
 type PromotionEdge struct {
-	SrcRegistry registry.RegistryContext
+	SrcRegistry registry.Context
 	SrcImageTag ImageTag
 
 	Digest image.Digest
 
-	DstRegistry registry.RegistryContext
+	DstRegistry registry.Context
 	DstImageTag ImageTag
 }
 
@@ -206,7 +206,7 @@ type RegistryImagePath string
 // GCRManifestListContext is used only for reading GCRManifestList information
 // from GCR, in the function ReadGCRManifestLists.
 type GCRManifestListContext struct {
-	RegistryContext registry.RegistryContext
+	RegistryContext registry.Context
 	ImageName       image.Name
 	Tag             image.Tag
 	Digest          image.Digest
@@ -248,7 +248,7 @@ type ProcessRequest func(
 type PromotionContext func(
 	image.Registry, // srcRegistry
 	image.Name, // srcImage
-	registry.RegistryContext, // destRegistryContext (need service acc)
+	registry.Context, // destRegistryContext (need service acc)
 	image.Name, // destImage
 	image.Digest,
 	image.Tag,

--- a/internal/legacy/remotemanifest/fake.go
+++ b/internal/legacy/remotemanifest/fake.go
@@ -17,22 +17,22 @@ limitations under the License.
 package remotemanifest
 
 import (
-	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 )
 
 // Fake is a fake remote manifest. It is fake in the sense that it
 // will never fetch anything from any remote.
 type Fake struct {
-	manifests []reg.Manifest
+	manifests []manifest.Manifest
 }
 
 // Fetch just returns the manifests that were set in NewFakeRemoteManifest.
-func (remote *Fake) Fetch() ([]reg.Manifest, error) {
+func (remote *Fake) Fetch() ([]manifest.Manifest, error) {
 	return remote.manifests, nil
 }
 
 // NewFake creates a new Fake.
-func NewFake(manifests []reg.Manifest) *Fake {
+func NewFake(manifests []manifest.Manifest) *Fake {
 	remote := Fake{}
 
 	remote.manifests = manifests

--- a/internal/legacy/remotemanifest/fake.go
+++ b/internal/legacy/remotemanifest/fake.go
@@ -16,23 +16,21 @@ limitations under the License.
 
 package remotemanifest
 
-import (
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
-)
+import "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 
 // Fake is a fake remote manifest. It is fake in the sense that it
 // will never fetch anything from any remote.
 type Fake struct {
-	manifests []manifest.Manifest
+	manifests []schema.Manifest
 }
 
 // Fetch just returns the manifests that were set in NewFakeRemoteManifest.
-func (remote *Fake) Fetch() ([]manifest.Manifest, error) {
+func (remote *Fake) Fetch() ([]schema.Manifest, error) {
 	return remote.manifests, nil
 }
 
 // NewFake creates a new Fake.
-func NewFake(manifests []manifest.Manifest) *Fake {
+func NewFake(manifests []schema.Manifest) *Fake {
 	remote := Fake{}
 
 	remote.manifests = manifests

--- a/internal/legacy/remotemanifest/git.go
+++ b/internal/legacy/remotemanifest/git.go
@@ -27,7 +27,7 @@ import (
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 )
 
 const (
@@ -47,10 +47,10 @@ type Git struct {
 // disk (in the case of e2e tests where we do not have a full-fledged online
 // repository for the manifests we want to audit) --- in such cases, we have to
 // use the local path instead of freshly cloning a remote repo.
-func (remote *Git) Fetch() ([]reg.Manifest, error) {
+func (remote *Git) Fetch() ([]manifest.Manifest, error) {
 	// There is no remote; use the local path directly.
 	if remote.repoURL.String() == "" {
-		manifests, err := reg.ParseThinManifestsFromDir(
+		manifests, err := manifest.ParseThinManifestsFromDir(
 			remote.thinManifestDirPath)
 		if err != nil {
 			return nil, err
@@ -65,7 +65,7 @@ func (remote *Git) Fetch() ([]reg.Manifest, error) {
 		return nil, err
 	}
 
-	manifests, err := reg.ParseThinManifestsFromDir(
+	manifests, err := manifest.ParseThinManifestsFromDir(
 		filepath.Join(repoPath, remote.thinManifestDirPath))
 	if err != nil {
 		return nil, err

--- a/internal/legacy/remotemanifest/git.go
+++ b/internal/legacy/remotemanifest/git.go
@@ -27,7 +27,7 @@ import (
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 )
 
 const (
@@ -47,10 +47,10 @@ type Git struct {
 // disk (in the case of e2e tests where we do not have a full-fledged online
 // repository for the manifests we want to audit) --- in such cases, we have to
 // use the local path instead of freshly cloning a remote repo.
-func (remote *Git) Fetch() ([]manifest.Manifest, error) {
+func (remote *Git) Fetch() ([]schema.Manifest, error) {
 	// There is no remote; use the local path directly.
 	if remote.repoURL.String() == "" {
-		manifests, err := manifest.ParseThinManifestsFromDir(
+		manifests, err := schema.ParseThinManifestsFromDir(
 			remote.thinManifestDirPath)
 		if err != nil {
 			return nil, err
@@ -65,7 +65,7 @@ func (remote *Git) Fetch() ([]manifest.Manifest, error) {
 		return nil, err
 	}
 
-	manifests, err := manifest.ParseThinManifestsFromDir(
+	manifests, err := schema.ParseThinManifestsFromDir(
 		filepath.Join(repoPath, remote.thinManifestDirPath))
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func getHeadSha(repo *gogit.Repository) (string, error) {
 }
 
 // NewGit creates a new Git implementation for defining a remote set of promoter
-// manifest.
+// schema.
 func NewGit(
 	repoURLStr string,
 	repoBranch string,

--- a/internal/legacy/remotemanifest/types.go
+++ b/internal/legacy/remotemanifest/types.go
@@ -16,12 +16,10 @@ limitations under the License.
 
 package remotemanifest
 
-import (
-	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-)
+import "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 
 // Facility requires a single method, called Fetch(), which corresponds to
 // fetching a set of promoter manifests.
 type Facility interface {
-	Fetch() ([]reg.Manifest, error)
+	Fetch() ([]manifest.Manifest, error)
 }

--- a/internal/legacy/remotemanifest/types.go
+++ b/internal/legacy/remotemanifest/types.go
@@ -16,10 +16,10 @@ limitations under the License.
 
 package remotemanifest
 
-import "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+import "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 
 // Facility requires a single method, called Fetch(), which corresponds to
 // fetching a set of promoter manifests.
 type Facility interface {
-	Fetch() ([]manifest.Manifest, error)
+	Fetch() ([]schema.Manifest, error)
 }

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -20,6 +20,8 @@ import (
 	"github.com/pkg/errors"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 	"sigs.k8s.io/promo-tools/v3/types/image"
@@ -30,18 +32,18 @@ import (
 
 // ParseManifests reads the manifest file or manifest directory
 // and parses them to return a slice of Manifest objects.
-func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (mfests []reg.Manifest, err error) {
+func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (mfests []manifest.Manifest, err error) {
 	// If the options have a manifest file defined, we use that one
 	if opts.Manifest != "" {
-		mfest, err := reg.ParseManifestFromFile(opts.Manifest)
+		mfest, err := manifest.ParseManifestFromFile(opts.Manifest)
 		if err != nil {
 			return mfests, errors.Wrap(err, "parsing the manifest file")
 		}
 
-		mfests = []reg.Manifest{mfest}
+		mfests = []manifest.Manifest{mfest}
 		// The thin manifests
 	} else if opts.ThinManifestDir != "" {
-		mfests, err = reg.ParseThinManifestsFromDir(opts.ThinManifestDir)
+		mfests, err = manifest.ParseThinManifestsFromDir(opts.ThinManifestDir)
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing thin manifest directory")
 		}
@@ -52,7 +54,7 @@ func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (
 // MakeSyncContext takes a slice of manifests and creates a sync context
 // object based on them and the promoter options
 func (di DefaultPromoterImplementation) MakeSyncContext(
-	opts *options.Options, mfests []reg.Manifest,
+	opts *options.Options, mfests []manifest.Manifest,
 ) (*reg.SyncContext, error) {
 	sc, err := reg.MakeSyncContext(
 		mfests, opts.Threads, opts.Confirm, opts.UseServiceAcct,
@@ -67,7 +69,7 @@ func (di DefaultPromoterImplementation) MakeSyncContext(
 // them the promotion edges, ie the images that need to be
 // promoted.
 func (di *DefaultPromoterImplementation) GetPromotionEdges(
-	sc *reg.SyncContext, mfests []reg.Manifest,
+	sc *reg.SyncContext, mfests []manifest.Manifest,
 ) (promotionEdges map[reg.PromotionEdge]interface{}, err error) {
 	// First, get the "edges" from the manifests
 	promotionEdges, err = reg.ToPromotionEdges(mfests)
@@ -93,7 +95,7 @@ func (di *DefaultPromoterImplementation) MakeProducerFunction(useServiceAccount 
 	return func(
 		srcRegistry image.Registry,
 		srcImageName image.Name,
-		destRC reg.RegistryContext,
+		destRC registry.RegistryContext,
 		imageName image.Name,
 		digest image.Digest, tag image.Tag, tp reg.TagOp,
 	) stream.Producer {

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -20,8 +20,8 @@ import (
 	"github.com/pkg/errors"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 	"sigs.k8s.io/promo-tools/v3/types/image"
@@ -32,18 +32,18 @@ import (
 
 // ParseManifests reads the manifest file or manifest directory
 // and parses them to return a slice of Manifest objects.
-func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (mfests []manifest.Manifest, err error) {
+func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (mfests []schema.Manifest, err error) {
 	// If the options have a manifest file defined, we use that one
 	if opts.Manifest != "" {
-		mfest, err := manifest.ParseManifestFromFile(opts.Manifest)
+		mfest, err := schema.ParseManifestFromFile(opts.Manifest)
 		if err != nil {
 			return mfests, errors.Wrap(err, "parsing the manifest file")
 		}
 
-		mfests = []manifest.Manifest{mfest}
+		mfests = []schema.Manifest{mfest}
 		// The thin manifests
 	} else if opts.ThinManifestDir != "" {
-		mfests, err = manifest.ParseThinManifestsFromDir(opts.ThinManifestDir)
+		mfests, err = schema.ParseThinManifestsFromDir(opts.ThinManifestDir)
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing thin manifest directory")
 		}
@@ -54,7 +54,7 @@ func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (
 // MakeSyncContext takes a slice of manifests and creates a sync context
 // object based on them and the promoter options
 func (di DefaultPromoterImplementation) MakeSyncContext(
-	opts *options.Options, mfests []manifest.Manifest,
+	opts *options.Options, mfests []schema.Manifest,
 ) (*reg.SyncContext, error) {
 	sc, err := reg.MakeSyncContext(
 		mfests, opts.Threads, opts.Confirm, opts.UseServiceAcct,
@@ -69,7 +69,7 @@ func (di DefaultPromoterImplementation) MakeSyncContext(
 // them the promotion edges, ie the images that need to be
 // promoted.
 func (di *DefaultPromoterImplementation) GetPromotionEdges(
-	sc *reg.SyncContext, mfests []manifest.Manifest,
+	sc *reg.SyncContext, mfests []schema.Manifest,
 ) (promotionEdges map[reg.PromotionEdge]interface{}, err error) {
 	// First, get the "edges" from the manifests
 	promotionEdges, err = reg.ToPromotionEdges(mfests)

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -95,7 +95,7 @@ func (di *DefaultPromoterImplementation) MakeProducerFunction(useServiceAccount 
 	return func(
 		srcRegistry image.Registry,
 		srcImageName image.Name,
-		destRC registry.RegistryContext,
+		destRC registry.Context,
 		imageName image.Name,
 		digest image.Digest, tag image.Tag, tp reg.TagOp,
 	) stream.Producer {

--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -40,7 +40,7 @@ necessarily mean that a new version of the image layer is available.`
 // construct a promotion stream producer
 type StreamProducerFunc func(
 	srcRegistry image.Registry, srcImageName image.Name,
-	destRC registry.RegistryContext, imageName image.Name,
+	destRC registry.Context, imageName image.Name,
 	digest image.Digest, tag image.Tag, tp reg.TagOp,
 ) stream.Producer
 

--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -21,8 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/gcloud"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 	"sigs.k8s.io/promo-tools/v3/internal/version"
@@ -91,7 +91,7 @@ func (di *DefaultPromoterImplementation) ActivateServiceAccounts(opts *options.O
 // PrecheckAndExit run simple prechecks to exit before promotions
 // or security scans
 func (di *DefaultPromoterImplementation) PrecheckAndExit(
-	opts *options.Options, mfests []manifest.Manifest,
+	opts *options.Options, mfests []schema.Manifest,
 ) error {
 	// Make the sync context tu run the prechecks:
 	sc, err := di.MakeSyncContext(opts, mfests)

--- a/internal/promoter/image/snapshot.go
+++ b/internal/promoter/image/snapshot.go
@@ -52,9 +52,9 @@ func (di *DefaultPromoterImplementation) Snapshot(opts *options.Options, rii reg
 
 func (di *DefaultPromoterImplementation) GetSnapshotSourceRegistry(
 	opts *options.Options,
-) (*registry.RegistryContext, error) {
+) (*registry.Context, error) {
 	// Build the source registry:
-	srcRegistry := &registry.RegistryContext{
+	srcRegistry := &registry.Context{
 		ServiceAccount: opts.SnapshotSvcAcct,
 		Src:            true,
 	}
@@ -89,7 +89,7 @@ func (di *DefaultPromoterImplementation) GetSnapshotManifests(
 	// Add it to a new manifest and return it:
 	return []manifest.Manifest{
 		{
-			Registries: []registry.RegistryContext{
+			Registries: []registry.Context{
 				*srcRegistry,
 			},
 			Images: []registry.Image{},
@@ -153,7 +153,7 @@ func (di *DefaultPromoterImplementation) GetRegistryImageInventory(
 
 		if opts.MinimalSnapshot {
 			if err := sc.ReadRegistriesGGCR(
-				[]registry.RegistryContext{*srcRegistry},
+				[]registry.Context{*srcRegistry},
 				true,
 			); err != nil {
 				return nil, errors.Wrap(err, "reading registry for minimal snapshot")
@@ -167,7 +167,7 @@ func (di *DefaultPromoterImplementation) GetRegistryImageInventory(
 	}
 
 	if err := sc.ReadRegistriesGGCR(
-		[]registry.RegistryContext{*srcRegistry}, true,
+		[]registry.Context{*srcRegistry}, true,
 	); err != nil {
 		return nil, errors.Wrap(err, "reading registries")
 	}

--- a/internal/promoter/image/snapshot.go
+++ b/internal/promoter/image/snapshot.go
@@ -24,8 +24,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
@@ -79,7 +79,7 @@ func (di *DefaultPromoterImplementation) GetSnapshotSourceRegistry(
 // specified snapshot source
 func (di *DefaultPromoterImplementation) GetSnapshotManifests(
 	opts *options.Options,
-) ([]manifest.Manifest, error) {
+) ([]schema.Manifest, error) {
 	// Build the source registry:
 	srcRegistry, err := di.GetSnapshotSourceRegistry(opts)
 	if err != nil {
@@ -87,7 +87,7 @@ func (di *DefaultPromoterImplementation) GetSnapshotManifests(
 	}
 
 	// Add it to a new manifest and return it:
-	return []manifest.Manifest{
+	return []schema.Manifest{
 		{
 			Registries: []registry.Context{
 				*srcRegistry,
@@ -102,8 +102,8 @@ func (di *DefaultPromoterImplementation) GetSnapshotManifests(
 // append it to the list of manifests generated for the snapshot
 // during GetSnapshotManifests()
 func (di *DefaultPromoterImplementation) AppendManifestToSnapshot(
-	opts *options.Options, mfests []manifest.Manifest,
-) ([]manifest.Manifest, error) {
+	opts *options.Options, mfests []schema.Manifest,
+) ([]schema.Manifest, error) {
 	// If no manifest was passed in the options, we return the
 	// same list of manifests unchanged
 	if opts.Manifest == "" {
@@ -112,7 +112,7 @@ func (di *DefaultPromoterImplementation) AppendManifestToSnapshot(
 	}
 
 	// Parse the specified manifest and append it to the list
-	mfest, err := manifest.ParseManifestFromFile(opts.Manifest)
+	mfest, err := schema.ParseManifestFromFile(opts.Manifest)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing specified manifest")
 	}
@@ -122,7 +122,7 @@ func (di *DefaultPromoterImplementation) AppendManifestToSnapshot(
 
 //
 func (di *DefaultPromoterImplementation) GetRegistryImageInventory(
-	opts *options.Options, mfests []manifest.Manifest,
+	opts *options.Options, mfests []schema.Manifest,
 ) (registry.RegInvImage, error) {
 	// I'm pretty sure the registry context here can be the same for
 	// both snapshot sources and when running in the original cli/run,

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -94,17 +94,17 @@ type FakePromoterImplementation struct {
 		result1 []manifest.Manifest
 		result2 error
 	}
-	GetSnapshotSourceRegistryStub        func(*imagepromotera.Options) (*registry.RegistryContext, error)
+	GetSnapshotSourceRegistryStub        func(*imagepromotera.Options) (*registry.Context, error)
 	getSnapshotSourceRegistryMutex       sync.RWMutex
 	getSnapshotSourceRegistryArgsForCall []struct {
 		arg1 *imagepromotera.Options
 	}
 	getSnapshotSourceRegistryReturns struct {
-		result1 *registry.RegistryContext
+		result1 *registry.Context
 		result2 error
 	}
 	getSnapshotSourceRegistryReturnsOnCall map[int]struct {
-		result1 *registry.RegistryContext
+		result1 *registry.Context
 		result2 error
 	}
 	MakeProducerFunctionStub        func(bool) imagepromoterb.StreamProducerFunc
@@ -607,7 +607,7 @@ func (fake *FakePromoterImplementation) GetSnapshotManifestsReturnsOnCall(i int,
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotSourceRegistry(arg1 *imagepromotera.Options) (*registry.RegistryContext, error) {
+func (fake *FakePromoterImplementation) GetSnapshotSourceRegistry(arg1 *imagepromotera.Options) (*registry.Context, error) {
 	fake.getSnapshotSourceRegistryMutex.Lock()
 	ret, specificReturn := fake.getSnapshotSourceRegistryReturnsOnCall[len(fake.getSnapshotSourceRegistryArgsForCall)]
 	fake.getSnapshotSourceRegistryArgsForCall = append(fake.getSnapshotSourceRegistryArgsForCall, struct {
@@ -632,7 +632,7 @@ func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryCallCount() int
 	return len(fake.getSnapshotSourceRegistryArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryCalls(stub func(*imagepromotera.Options) (*registry.RegistryContext, error)) {
+func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryCalls(stub func(*imagepromotera.Options) (*registry.Context, error)) {
 	fake.getSnapshotSourceRegistryMutex.Lock()
 	defer fake.getSnapshotSourceRegistryMutex.Unlock()
 	fake.GetSnapshotSourceRegistryStub = stub
@@ -645,28 +645,28 @@ func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryArgsForCall(i i
 	return argsForCall.arg1
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryReturns(result1 *registry.RegistryContext, result2 error) {
+func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryReturns(result1 *registry.Context, result2 error) {
 	fake.getSnapshotSourceRegistryMutex.Lock()
 	defer fake.getSnapshotSourceRegistryMutex.Unlock()
 	fake.GetSnapshotSourceRegistryStub = nil
 	fake.getSnapshotSourceRegistryReturns = struct {
-		result1 *registry.RegistryContext
+		result1 *registry.Context
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryReturnsOnCall(i int, result1 *registry.RegistryContext, result2 error) {
+func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryReturnsOnCall(i int, result1 *registry.Context, result2 error) {
 	fake.getSnapshotSourceRegistryMutex.Lock()
 	defer fake.getSnapshotSourceRegistryMutex.Unlock()
 	fake.GetSnapshotSourceRegistryStub = nil
 	if fake.getSnapshotSourceRegistryReturnsOnCall == nil {
 		fake.getSnapshotSourceRegistryReturnsOnCall = make(map[int]struct {
-			result1 *registry.RegistryContext
+			result1 *registry.Context
 			result2 error
 		})
 	}
 	fake.getSnapshotSourceRegistryReturnsOnCall[i] = struct {
-		result1 *registry.RegistryContext
+		result1 *registry.Context
 		result2 error
 	}{result1, result2}
 }

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 
 	inventory "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	imagepromoterb "sigs.k8s.io/promo-tools/v3/internal/promoter/image"
 	imagepromotera "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 )
@@ -37,25 +39,25 @@ type FakePromoterImplementation struct {
 	activateServiceAccountsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	AppendManifestToSnapshotStub        func(*imagepromotera.Options, []inventory.Manifest) ([]inventory.Manifest, error)
+	AppendManifestToSnapshotStub        func(*imagepromotera.Options, []manifest.Manifest) ([]manifest.Manifest, error)
 	appendManifestToSnapshotMutex       sync.RWMutex
 	appendManifestToSnapshotArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}
 	appendManifestToSnapshotReturns struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}
 	appendManifestToSnapshotReturnsOnCall map[int]struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}
-	GetPromotionEdgesStub        func(*inventory.SyncContext, []inventory.Manifest) (map[inventory.PromotionEdge]interface{}, error)
+	GetPromotionEdgesStub        func(*inventory.SyncContext, []manifest.Manifest) (map[inventory.PromotionEdge]interface{}, error)
 	getPromotionEdgesMutex       sync.RWMutex
 	getPromotionEdgesArgsForCall []struct {
 		arg1 *inventory.SyncContext
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}
 	getPromotionEdgesReturns struct {
 		result1 map[inventory.PromotionEdge]interface{}
@@ -65,44 +67,44 @@ type FakePromoterImplementation struct {
 		result1 map[inventory.PromotionEdge]interface{}
 		result2 error
 	}
-	GetRegistryImageInventoryStub        func(*imagepromotera.Options, []inventory.Manifest) (inventory.RegInvImage, error)
+	GetRegistryImageInventoryStub        func(*imagepromotera.Options, []manifest.Manifest) (registry.RegInvImage, error)
 	getRegistryImageInventoryMutex       sync.RWMutex
 	getRegistryImageInventoryArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}
 	getRegistryImageInventoryReturns struct {
-		result1 inventory.RegInvImage
+		result1 registry.RegInvImage
 		result2 error
 	}
 	getRegistryImageInventoryReturnsOnCall map[int]struct {
-		result1 inventory.RegInvImage
+		result1 registry.RegInvImage
 		result2 error
 	}
-	GetSnapshotManifestsStub        func(*imagepromotera.Options) ([]inventory.Manifest, error)
+	GetSnapshotManifestsStub        func(*imagepromotera.Options) ([]manifest.Manifest, error)
 	getSnapshotManifestsMutex       sync.RWMutex
 	getSnapshotManifestsArgsForCall []struct {
 		arg1 *imagepromotera.Options
 	}
 	getSnapshotManifestsReturns struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}
 	getSnapshotManifestsReturnsOnCall map[int]struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}
-	GetSnapshotSourceRegistryStub        func(*imagepromotera.Options) (*inventory.RegistryContext, error)
+	GetSnapshotSourceRegistryStub        func(*imagepromotera.Options) (*registry.RegistryContext, error)
 	getSnapshotSourceRegistryMutex       sync.RWMutex
 	getSnapshotSourceRegistryArgsForCall []struct {
 		arg1 *imagepromotera.Options
 	}
 	getSnapshotSourceRegistryReturns struct {
-		result1 *inventory.RegistryContext
+		result1 *registry.RegistryContext
 		result2 error
 	}
 	getSnapshotSourceRegistryReturnsOnCall map[int]struct {
-		result1 *inventory.RegistryContext
+		result1 *registry.RegistryContext
 		result2 error
 	}
 	MakeProducerFunctionStub        func(bool) imagepromoterb.StreamProducerFunc
@@ -116,11 +118,11 @@ type FakePromoterImplementation struct {
 	makeProducerFunctionReturnsOnCall map[int]struct {
 		result1 imagepromoterb.StreamProducerFunc
 	}
-	MakeSyncContextStub        func(*imagepromotera.Options, []inventory.Manifest) (*inventory.SyncContext, error)
+	MakeSyncContextStub        func(*imagepromotera.Options, []manifest.Manifest) (*inventory.SyncContext, error)
 	makeSyncContextMutex       sync.RWMutex
 	makeSyncContextArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}
 	makeSyncContextReturns struct {
 		result1 *inventory.SyncContext
@@ -130,24 +132,24 @@ type FakePromoterImplementation struct {
 		result1 *inventory.SyncContext
 		result2 error
 	}
-	ParseManifestsStub        func(*imagepromotera.Options) ([]inventory.Manifest, error)
+	ParseManifestsStub        func(*imagepromotera.Options) ([]manifest.Manifest, error)
 	parseManifestsMutex       sync.RWMutex
 	parseManifestsArgsForCall []struct {
 		arg1 *imagepromotera.Options
 	}
 	parseManifestsReturns struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}
 	parseManifestsReturnsOnCall map[int]struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}
-	PrecheckAndExitStub        func(*imagepromotera.Options, []inventory.Manifest) error
+	PrecheckAndExitStub        func(*imagepromotera.Options, []manifest.Manifest) error
 	precheckAndExitMutex       sync.RWMutex
 	precheckAndExitArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}
 	precheckAndExitReturns struct {
 		result1 error
@@ -208,11 +210,11 @@ type FakePromoterImplementation struct {
 	signImagesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SnapshotStub        func(*imagepromotera.Options, inventory.RegInvImage) error
+	SnapshotStub        func(*imagepromotera.Options, registry.RegInvImage) error
 	snapshotMutex       sync.RWMutex
 	snapshotArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 inventory.RegInvImage
+		arg2 registry.RegInvImage
 	}
 	snapshotReturns struct {
 		result1 error
@@ -331,17 +333,17 @@ func (fake *FakePromoterImplementation) ActivateServiceAccountsReturnsOnCall(i i
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshot(arg1 *imagepromotera.Options, arg2 []inventory.Manifest) ([]inventory.Manifest, error) {
-	var arg2Copy []inventory.Manifest
+func (fake *FakePromoterImplementation) AppendManifestToSnapshot(arg1 *imagepromotera.Options, arg2 []manifest.Manifest) ([]manifest.Manifest, error) {
+	var arg2Copy []manifest.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]inventory.Manifest, len(arg2))
+		arg2Copy = make([]manifest.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.appendManifestToSnapshotMutex.Lock()
 	ret, specificReturn := fake.appendManifestToSnapshotReturnsOnCall[len(fake.appendManifestToSnapshotArgsForCall)]
 	fake.appendManifestToSnapshotArgsForCall = append(fake.appendManifestToSnapshotArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.AppendManifestToSnapshotStub
 	fakeReturns := fake.appendManifestToSnapshotReturns
@@ -362,56 +364,56 @@ func (fake *FakePromoterImplementation) AppendManifestToSnapshotCallCount() int 
 	return len(fake.appendManifestToSnapshotArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshotCalls(stub func(*imagepromotera.Options, []inventory.Manifest) ([]inventory.Manifest, error)) {
+func (fake *FakePromoterImplementation) AppendManifestToSnapshotCalls(stub func(*imagepromotera.Options, []manifest.Manifest) ([]manifest.Manifest, error)) {
 	fake.appendManifestToSnapshotMutex.Lock()
 	defer fake.appendManifestToSnapshotMutex.Unlock()
 	fake.AppendManifestToSnapshotStub = stub
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshotArgsForCall(i int) (*imagepromotera.Options, []inventory.Manifest) {
+func (fake *FakePromoterImplementation) AppendManifestToSnapshotArgsForCall(i int) (*imagepromotera.Options, []manifest.Manifest) {
 	fake.appendManifestToSnapshotMutex.RLock()
 	defer fake.appendManifestToSnapshotMutex.RUnlock()
 	argsForCall := fake.appendManifestToSnapshotArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturns(result1 []inventory.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturns(result1 []manifest.Manifest, result2 error) {
 	fake.appendManifestToSnapshotMutex.Lock()
 	defer fake.appendManifestToSnapshotMutex.Unlock()
 	fake.AppendManifestToSnapshotStub = nil
 	fake.appendManifestToSnapshotReturns = struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i int, result1 []inventory.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i int, result1 []manifest.Manifest, result2 error) {
 	fake.appendManifestToSnapshotMutex.Lock()
 	defer fake.appendManifestToSnapshotMutex.Unlock()
 	fake.AppendManifestToSnapshotStub = nil
 	if fake.appendManifestToSnapshotReturnsOnCall == nil {
 		fake.appendManifestToSnapshotReturnsOnCall = make(map[int]struct {
-			result1 []inventory.Manifest
+			result1 []manifest.Manifest
 			result2 error
 		})
 	}
 	fake.appendManifestToSnapshotReturnsOnCall[i] = struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdges(arg1 *inventory.SyncContext, arg2 []inventory.Manifest) (map[inventory.PromotionEdge]interface{}, error) {
-	var arg2Copy []inventory.Manifest
+func (fake *FakePromoterImplementation) GetPromotionEdges(arg1 *inventory.SyncContext, arg2 []manifest.Manifest) (map[inventory.PromotionEdge]interface{}, error) {
+	var arg2Copy []manifest.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]inventory.Manifest, len(arg2))
+		arg2Copy = make([]manifest.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.getPromotionEdgesMutex.Lock()
 	ret, specificReturn := fake.getPromotionEdgesReturnsOnCall[len(fake.getPromotionEdgesArgsForCall)]
 	fake.getPromotionEdgesArgsForCall = append(fake.getPromotionEdgesArgsForCall, struct {
 		arg1 *inventory.SyncContext
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.GetPromotionEdgesStub
 	fakeReturns := fake.getPromotionEdgesReturns
@@ -432,13 +434,13 @@ func (fake *FakePromoterImplementation) GetPromotionEdgesCallCount() int {
 	return len(fake.getPromotionEdgesArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdgesCalls(stub func(*inventory.SyncContext, []inventory.Manifest) (map[inventory.PromotionEdge]interface{}, error)) {
+func (fake *FakePromoterImplementation) GetPromotionEdgesCalls(stub func(*inventory.SyncContext, []manifest.Manifest) (map[inventory.PromotionEdge]interface{}, error)) {
 	fake.getPromotionEdgesMutex.Lock()
 	defer fake.getPromotionEdgesMutex.Unlock()
 	fake.GetPromotionEdgesStub = stub
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdgesArgsForCall(i int) (*inventory.SyncContext, []inventory.Manifest) {
+func (fake *FakePromoterImplementation) GetPromotionEdgesArgsForCall(i int) (*inventory.SyncContext, []manifest.Manifest) {
 	fake.getPromotionEdgesMutex.RLock()
 	defer fake.getPromotionEdgesMutex.RUnlock()
 	argsForCall := fake.getPromotionEdgesArgsForCall[i]
@@ -471,17 +473,17 @@ func (fake *FakePromoterImplementation) GetPromotionEdgesReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetRegistryImageInventory(arg1 *imagepromotera.Options, arg2 []inventory.Manifest) (inventory.RegInvImage, error) {
-	var arg2Copy []inventory.Manifest
+func (fake *FakePromoterImplementation) GetRegistryImageInventory(arg1 *imagepromotera.Options, arg2 []manifest.Manifest) (registry.RegInvImage, error) {
+	var arg2Copy []manifest.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]inventory.Manifest, len(arg2))
+		arg2Copy = make([]manifest.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.getRegistryImageInventoryMutex.Lock()
 	ret, specificReturn := fake.getRegistryImageInventoryReturnsOnCall[len(fake.getRegistryImageInventoryArgsForCall)]
 	fake.getRegistryImageInventoryArgsForCall = append(fake.getRegistryImageInventoryArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.GetRegistryImageInventoryStub
 	fakeReturns := fake.getRegistryImageInventoryReturns
@@ -502,46 +504,46 @@ func (fake *FakePromoterImplementation) GetRegistryImageInventoryCallCount() int
 	return len(fake.getRegistryImageInventoryArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetRegistryImageInventoryCalls(stub func(*imagepromotera.Options, []inventory.Manifest) (inventory.RegInvImage, error)) {
+func (fake *FakePromoterImplementation) GetRegistryImageInventoryCalls(stub func(*imagepromotera.Options, []manifest.Manifest) (registry.RegInvImage, error)) {
 	fake.getRegistryImageInventoryMutex.Lock()
 	defer fake.getRegistryImageInventoryMutex.Unlock()
 	fake.GetRegistryImageInventoryStub = stub
 }
 
-func (fake *FakePromoterImplementation) GetRegistryImageInventoryArgsForCall(i int) (*imagepromotera.Options, []inventory.Manifest) {
+func (fake *FakePromoterImplementation) GetRegistryImageInventoryArgsForCall(i int) (*imagepromotera.Options, []manifest.Manifest) {
 	fake.getRegistryImageInventoryMutex.RLock()
 	defer fake.getRegistryImageInventoryMutex.RUnlock()
 	argsForCall := fake.getRegistryImageInventoryArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakePromoterImplementation) GetRegistryImageInventoryReturns(result1 inventory.RegInvImage, result2 error) {
+func (fake *FakePromoterImplementation) GetRegistryImageInventoryReturns(result1 registry.RegInvImage, result2 error) {
 	fake.getRegistryImageInventoryMutex.Lock()
 	defer fake.getRegistryImageInventoryMutex.Unlock()
 	fake.GetRegistryImageInventoryStub = nil
 	fake.getRegistryImageInventoryReturns = struct {
-		result1 inventory.RegInvImage
+		result1 registry.RegInvImage
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetRegistryImageInventoryReturnsOnCall(i int, result1 inventory.RegInvImage, result2 error) {
+func (fake *FakePromoterImplementation) GetRegistryImageInventoryReturnsOnCall(i int, result1 registry.RegInvImage, result2 error) {
 	fake.getRegistryImageInventoryMutex.Lock()
 	defer fake.getRegistryImageInventoryMutex.Unlock()
 	fake.GetRegistryImageInventoryStub = nil
 	if fake.getRegistryImageInventoryReturnsOnCall == nil {
 		fake.getRegistryImageInventoryReturnsOnCall = make(map[int]struct {
-			result1 inventory.RegInvImage
+			result1 registry.RegInvImage
 			result2 error
 		})
 	}
 	fake.getRegistryImageInventoryReturnsOnCall[i] = struct {
-		result1 inventory.RegInvImage
+		result1 registry.RegInvImage
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotManifests(arg1 *imagepromotera.Options) ([]inventory.Manifest, error) {
+func (fake *FakePromoterImplementation) GetSnapshotManifests(arg1 *imagepromotera.Options) ([]manifest.Manifest, error) {
 	fake.getSnapshotManifestsMutex.Lock()
 	ret, specificReturn := fake.getSnapshotManifestsReturnsOnCall[len(fake.getSnapshotManifestsArgsForCall)]
 	fake.getSnapshotManifestsArgsForCall = append(fake.getSnapshotManifestsArgsForCall, struct {
@@ -566,7 +568,7 @@ func (fake *FakePromoterImplementation) GetSnapshotManifestsCallCount() int {
 	return len(fake.getSnapshotManifestsArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotManifestsCalls(stub func(*imagepromotera.Options) ([]inventory.Manifest, error)) {
+func (fake *FakePromoterImplementation) GetSnapshotManifestsCalls(stub func(*imagepromotera.Options) ([]manifest.Manifest, error)) {
 	fake.getSnapshotManifestsMutex.Lock()
 	defer fake.getSnapshotManifestsMutex.Unlock()
 	fake.GetSnapshotManifestsStub = stub
@@ -579,33 +581,33 @@ func (fake *FakePromoterImplementation) GetSnapshotManifestsArgsForCall(i int) *
 	return argsForCall.arg1
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotManifestsReturns(result1 []inventory.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) GetSnapshotManifestsReturns(result1 []manifest.Manifest, result2 error) {
 	fake.getSnapshotManifestsMutex.Lock()
 	defer fake.getSnapshotManifestsMutex.Unlock()
 	fake.GetSnapshotManifestsStub = nil
 	fake.getSnapshotManifestsReturns = struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotManifestsReturnsOnCall(i int, result1 []inventory.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) GetSnapshotManifestsReturnsOnCall(i int, result1 []manifest.Manifest, result2 error) {
 	fake.getSnapshotManifestsMutex.Lock()
 	defer fake.getSnapshotManifestsMutex.Unlock()
 	fake.GetSnapshotManifestsStub = nil
 	if fake.getSnapshotManifestsReturnsOnCall == nil {
 		fake.getSnapshotManifestsReturnsOnCall = make(map[int]struct {
-			result1 []inventory.Manifest
+			result1 []manifest.Manifest
 			result2 error
 		})
 	}
 	fake.getSnapshotManifestsReturnsOnCall[i] = struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotSourceRegistry(arg1 *imagepromotera.Options) (*inventory.RegistryContext, error) {
+func (fake *FakePromoterImplementation) GetSnapshotSourceRegistry(arg1 *imagepromotera.Options) (*registry.RegistryContext, error) {
 	fake.getSnapshotSourceRegistryMutex.Lock()
 	ret, specificReturn := fake.getSnapshotSourceRegistryReturnsOnCall[len(fake.getSnapshotSourceRegistryArgsForCall)]
 	fake.getSnapshotSourceRegistryArgsForCall = append(fake.getSnapshotSourceRegistryArgsForCall, struct {
@@ -630,7 +632,7 @@ func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryCallCount() int
 	return len(fake.getSnapshotSourceRegistryArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryCalls(stub func(*imagepromotera.Options) (*inventory.RegistryContext, error)) {
+func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryCalls(stub func(*imagepromotera.Options) (*registry.RegistryContext, error)) {
 	fake.getSnapshotSourceRegistryMutex.Lock()
 	defer fake.getSnapshotSourceRegistryMutex.Unlock()
 	fake.GetSnapshotSourceRegistryStub = stub
@@ -643,28 +645,28 @@ func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryArgsForCall(i i
 	return argsForCall.arg1
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryReturns(result1 *inventory.RegistryContext, result2 error) {
+func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryReturns(result1 *registry.RegistryContext, result2 error) {
 	fake.getSnapshotSourceRegistryMutex.Lock()
 	defer fake.getSnapshotSourceRegistryMutex.Unlock()
 	fake.GetSnapshotSourceRegistryStub = nil
 	fake.getSnapshotSourceRegistryReturns = struct {
-		result1 *inventory.RegistryContext
+		result1 *registry.RegistryContext
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryReturnsOnCall(i int, result1 *inventory.RegistryContext, result2 error) {
+func (fake *FakePromoterImplementation) GetSnapshotSourceRegistryReturnsOnCall(i int, result1 *registry.RegistryContext, result2 error) {
 	fake.getSnapshotSourceRegistryMutex.Lock()
 	defer fake.getSnapshotSourceRegistryMutex.Unlock()
 	fake.GetSnapshotSourceRegistryStub = nil
 	if fake.getSnapshotSourceRegistryReturnsOnCall == nil {
 		fake.getSnapshotSourceRegistryReturnsOnCall = make(map[int]struct {
-			result1 *inventory.RegistryContext
+			result1 *registry.RegistryContext
 			result2 error
 		})
 	}
 	fake.getSnapshotSourceRegistryReturnsOnCall[i] = struct {
-		result1 *inventory.RegistryContext
+		result1 *registry.RegistryContext
 		result2 error
 	}{result1, result2}
 }
@@ -730,17 +732,17 @@ func (fake *FakePromoterImplementation) MakeProducerFunctionReturnsOnCall(i int,
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) MakeSyncContext(arg1 *imagepromotera.Options, arg2 []inventory.Manifest) (*inventory.SyncContext, error) {
-	var arg2Copy []inventory.Manifest
+func (fake *FakePromoterImplementation) MakeSyncContext(arg1 *imagepromotera.Options, arg2 []manifest.Manifest) (*inventory.SyncContext, error) {
+	var arg2Copy []manifest.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]inventory.Manifest, len(arg2))
+		arg2Copy = make([]manifest.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.makeSyncContextMutex.Lock()
 	ret, specificReturn := fake.makeSyncContextReturnsOnCall[len(fake.makeSyncContextArgsForCall)]
 	fake.makeSyncContextArgsForCall = append(fake.makeSyncContextArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.MakeSyncContextStub
 	fakeReturns := fake.makeSyncContextReturns
@@ -761,13 +763,13 @@ func (fake *FakePromoterImplementation) MakeSyncContextCallCount() int {
 	return len(fake.makeSyncContextArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) MakeSyncContextCalls(stub func(*imagepromotera.Options, []inventory.Manifest) (*inventory.SyncContext, error)) {
+func (fake *FakePromoterImplementation) MakeSyncContextCalls(stub func(*imagepromotera.Options, []manifest.Manifest) (*inventory.SyncContext, error)) {
 	fake.makeSyncContextMutex.Lock()
 	defer fake.makeSyncContextMutex.Unlock()
 	fake.MakeSyncContextStub = stub
 }
 
-func (fake *FakePromoterImplementation) MakeSyncContextArgsForCall(i int) (*imagepromotera.Options, []inventory.Manifest) {
+func (fake *FakePromoterImplementation) MakeSyncContextArgsForCall(i int) (*imagepromotera.Options, []manifest.Manifest) {
 	fake.makeSyncContextMutex.RLock()
 	defer fake.makeSyncContextMutex.RUnlock()
 	argsForCall := fake.makeSyncContextArgsForCall[i]
@@ -800,7 +802,7 @@ func (fake *FakePromoterImplementation) MakeSyncContextReturnsOnCall(i int, resu
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) ParseManifests(arg1 *imagepromotera.Options) ([]inventory.Manifest, error) {
+func (fake *FakePromoterImplementation) ParseManifests(arg1 *imagepromotera.Options) ([]manifest.Manifest, error) {
 	fake.parseManifestsMutex.Lock()
 	ret, specificReturn := fake.parseManifestsReturnsOnCall[len(fake.parseManifestsArgsForCall)]
 	fake.parseManifestsArgsForCall = append(fake.parseManifestsArgsForCall, struct {
@@ -825,7 +827,7 @@ func (fake *FakePromoterImplementation) ParseManifestsCallCount() int {
 	return len(fake.parseManifestsArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) ParseManifestsCalls(stub func(*imagepromotera.Options) ([]inventory.Manifest, error)) {
+func (fake *FakePromoterImplementation) ParseManifestsCalls(stub func(*imagepromotera.Options) ([]manifest.Manifest, error)) {
 	fake.parseManifestsMutex.Lock()
 	defer fake.parseManifestsMutex.Unlock()
 	fake.ParseManifestsStub = stub
@@ -838,43 +840,43 @@ func (fake *FakePromoterImplementation) ParseManifestsArgsForCall(i int) *imagep
 	return argsForCall.arg1
 }
 
-func (fake *FakePromoterImplementation) ParseManifestsReturns(result1 []inventory.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) ParseManifestsReturns(result1 []manifest.Manifest, result2 error) {
 	fake.parseManifestsMutex.Lock()
 	defer fake.parseManifestsMutex.Unlock()
 	fake.ParseManifestsStub = nil
 	fake.parseManifestsReturns = struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) ParseManifestsReturnsOnCall(i int, result1 []inventory.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) ParseManifestsReturnsOnCall(i int, result1 []manifest.Manifest, result2 error) {
 	fake.parseManifestsMutex.Lock()
 	defer fake.parseManifestsMutex.Unlock()
 	fake.ParseManifestsStub = nil
 	if fake.parseManifestsReturnsOnCall == nil {
 		fake.parseManifestsReturnsOnCall = make(map[int]struct {
-			result1 []inventory.Manifest
+			result1 []manifest.Manifest
 			result2 error
 		})
 	}
 	fake.parseManifestsReturnsOnCall[i] = struct {
-		result1 []inventory.Manifest
+		result1 []manifest.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) PrecheckAndExit(arg1 *imagepromotera.Options, arg2 []inventory.Manifest) error {
-	var arg2Copy []inventory.Manifest
+func (fake *FakePromoterImplementation) PrecheckAndExit(arg1 *imagepromotera.Options, arg2 []manifest.Manifest) error {
+	var arg2Copy []manifest.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]inventory.Manifest, len(arg2))
+		arg2Copy = make([]manifest.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.precheckAndExitMutex.Lock()
 	ret, specificReturn := fake.precheckAndExitReturnsOnCall[len(fake.precheckAndExitArgsForCall)]
 	fake.precheckAndExitArgsForCall = append(fake.precheckAndExitArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 []inventory.Manifest
+		arg2 []manifest.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.PrecheckAndExitStub
 	fakeReturns := fake.precheckAndExitReturns
@@ -895,13 +897,13 @@ func (fake *FakePromoterImplementation) PrecheckAndExitCallCount() int {
 	return len(fake.precheckAndExitArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) PrecheckAndExitCalls(stub func(*imagepromotera.Options, []inventory.Manifest) error) {
+func (fake *FakePromoterImplementation) PrecheckAndExitCalls(stub func(*imagepromotera.Options, []manifest.Manifest) error) {
 	fake.precheckAndExitMutex.Lock()
 	defer fake.precheckAndExitMutex.Unlock()
 	fake.PrecheckAndExitStub = stub
 }
 
-func (fake *FakePromoterImplementation) PrecheckAndExitArgsForCall(i int) (*imagepromotera.Options, []inventory.Manifest) {
+func (fake *FakePromoterImplementation) PrecheckAndExitArgsForCall(i int) (*imagepromotera.Options, []manifest.Manifest) {
 	fake.precheckAndExitMutex.RLock()
 	defer fake.precheckAndExitMutex.RUnlock()
 	argsForCall := fake.precheckAndExitArgsForCall[i]
@@ -1201,12 +1203,12 @@ func (fake *FakePromoterImplementation) SignImagesReturnsOnCall(i int, result1 e
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) Snapshot(arg1 *imagepromotera.Options, arg2 inventory.RegInvImage) error {
+func (fake *FakePromoterImplementation) Snapshot(arg1 *imagepromotera.Options, arg2 registry.RegInvImage) error {
 	fake.snapshotMutex.Lock()
 	ret, specificReturn := fake.snapshotReturnsOnCall[len(fake.snapshotArgsForCall)]
 	fake.snapshotArgsForCall = append(fake.snapshotArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 inventory.RegInvImage
+		arg2 registry.RegInvImage
 	}{arg1, arg2})
 	stub := fake.SnapshotStub
 	fakeReturns := fake.snapshotReturns
@@ -1227,13 +1229,13 @@ func (fake *FakePromoterImplementation) SnapshotCallCount() int {
 	return len(fake.snapshotArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) SnapshotCalls(stub func(*imagepromotera.Options, inventory.RegInvImage) error) {
+func (fake *FakePromoterImplementation) SnapshotCalls(stub func(*imagepromotera.Options, registry.RegInvImage) error) {
 	fake.snapshotMutex.Lock()
 	defer fake.snapshotMutex.Unlock()
 	fake.SnapshotStub = stub
 }
 
-func (fake *FakePromoterImplementation) SnapshotArgsForCall(i int) (*imagepromotera.Options, inventory.RegInvImage) {
+func (fake *FakePromoterImplementation) SnapshotArgsForCall(i int) (*imagepromotera.Options, registry.RegInvImage) {
 	fake.snapshotMutex.RLock()
 	defer fake.snapshotMutex.RUnlock()
 	argsForCall := fake.snapshotArgsForCall[i]

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 
 	inventory "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	imagepromoterb "sigs.k8s.io/promo-tools/v3/internal/promoter/image"
 	imagepromotera "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 )
@@ -39,25 +39,25 @@ type FakePromoterImplementation struct {
 	activateServiceAccountsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	AppendManifestToSnapshotStub        func(*imagepromotera.Options, []manifest.Manifest) ([]manifest.Manifest, error)
+	AppendManifestToSnapshotStub        func(*imagepromotera.Options, []schema.Manifest) ([]schema.Manifest, error)
 	appendManifestToSnapshotMutex       sync.RWMutex
 	appendManifestToSnapshotArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}
 	appendManifestToSnapshotReturns struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}
 	appendManifestToSnapshotReturnsOnCall map[int]struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}
-	GetPromotionEdgesStub        func(*inventory.SyncContext, []manifest.Manifest) (map[inventory.PromotionEdge]interface{}, error)
+	GetPromotionEdgesStub        func(*inventory.SyncContext, []schema.Manifest) (map[inventory.PromotionEdge]interface{}, error)
 	getPromotionEdgesMutex       sync.RWMutex
 	getPromotionEdgesArgsForCall []struct {
 		arg1 *inventory.SyncContext
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}
 	getPromotionEdgesReturns struct {
 		result1 map[inventory.PromotionEdge]interface{}
@@ -67,11 +67,11 @@ type FakePromoterImplementation struct {
 		result1 map[inventory.PromotionEdge]interface{}
 		result2 error
 	}
-	GetRegistryImageInventoryStub        func(*imagepromotera.Options, []manifest.Manifest) (registry.RegInvImage, error)
+	GetRegistryImageInventoryStub        func(*imagepromotera.Options, []schema.Manifest) (registry.RegInvImage, error)
 	getRegistryImageInventoryMutex       sync.RWMutex
 	getRegistryImageInventoryArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}
 	getRegistryImageInventoryReturns struct {
 		result1 registry.RegInvImage
@@ -81,17 +81,17 @@ type FakePromoterImplementation struct {
 		result1 registry.RegInvImage
 		result2 error
 	}
-	GetSnapshotManifestsStub        func(*imagepromotera.Options) ([]manifest.Manifest, error)
+	GetSnapshotManifestsStub        func(*imagepromotera.Options) ([]schema.Manifest, error)
 	getSnapshotManifestsMutex       sync.RWMutex
 	getSnapshotManifestsArgsForCall []struct {
 		arg1 *imagepromotera.Options
 	}
 	getSnapshotManifestsReturns struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}
 	getSnapshotManifestsReturnsOnCall map[int]struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}
 	GetSnapshotSourceRegistryStub        func(*imagepromotera.Options) (*registry.Context, error)
@@ -118,11 +118,11 @@ type FakePromoterImplementation struct {
 	makeProducerFunctionReturnsOnCall map[int]struct {
 		result1 imagepromoterb.StreamProducerFunc
 	}
-	MakeSyncContextStub        func(*imagepromotera.Options, []manifest.Manifest) (*inventory.SyncContext, error)
+	MakeSyncContextStub        func(*imagepromotera.Options, []schema.Manifest) (*inventory.SyncContext, error)
 	makeSyncContextMutex       sync.RWMutex
 	makeSyncContextArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}
 	makeSyncContextReturns struct {
 		result1 *inventory.SyncContext
@@ -132,24 +132,24 @@ type FakePromoterImplementation struct {
 		result1 *inventory.SyncContext
 		result2 error
 	}
-	ParseManifestsStub        func(*imagepromotera.Options) ([]manifest.Manifest, error)
+	ParseManifestsStub        func(*imagepromotera.Options) ([]schema.Manifest, error)
 	parseManifestsMutex       sync.RWMutex
 	parseManifestsArgsForCall []struct {
 		arg1 *imagepromotera.Options
 	}
 	parseManifestsReturns struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}
 	parseManifestsReturnsOnCall map[int]struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}
-	PrecheckAndExitStub        func(*imagepromotera.Options, []manifest.Manifest) error
+	PrecheckAndExitStub        func(*imagepromotera.Options, []schema.Manifest) error
 	precheckAndExitMutex       sync.RWMutex
 	precheckAndExitArgsForCall []struct {
 		arg1 *imagepromotera.Options
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}
 	precheckAndExitReturns struct {
 		result1 error
@@ -333,17 +333,17 @@ func (fake *FakePromoterImplementation) ActivateServiceAccountsReturnsOnCall(i i
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshot(arg1 *imagepromotera.Options, arg2 []manifest.Manifest) ([]manifest.Manifest, error) {
-	var arg2Copy []manifest.Manifest
+func (fake *FakePromoterImplementation) AppendManifestToSnapshot(arg1 *imagepromotera.Options, arg2 []schema.Manifest) ([]schema.Manifest, error) {
+	var arg2Copy []schema.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]manifest.Manifest, len(arg2))
+		arg2Copy = make([]schema.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.appendManifestToSnapshotMutex.Lock()
 	ret, specificReturn := fake.appendManifestToSnapshotReturnsOnCall[len(fake.appendManifestToSnapshotArgsForCall)]
 	fake.appendManifestToSnapshotArgsForCall = append(fake.appendManifestToSnapshotArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.AppendManifestToSnapshotStub
 	fakeReturns := fake.appendManifestToSnapshotReturns
@@ -364,56 +364,56 @@ func (fake *FakePromoterImplementation) AppendManifestToSnapshotCallCount() int 
 	return len(fake.appendManifestToSnapshotArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshotCalls(stub func(*imagepromotera.Options, []manifest.Manifest) ([]manifest.Manifest, error)) {
+func (fake *FakePromoterImplementation) AppendManifestToSnapshotCalls(stub func(*imagepromotera.Options, []schema.Manifest) ([]schema.Manifest, error)) {
 	fake.appendManifestToSnapshotMutex.Lock()
 	defer fake.appendManifestToSnapshotMutex.Unlock()
 	fake.AppendManifestToSnapshotStub = stub
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshotArgsForCall(i int) (*imagepromotera.Options, []manifest.Manifest) {
+func (fake *FakePromoterImplementation) AppendManifestToSnapshotArgsForCall(i int) (*imagepromotera.Options, []schema.Manifest) {
 	fake.appendManifestToSnapshotMutex.RLock()
 	defer fake.appendManifestToSnapshotMutex.RUnlock()
 	argsForCall := fake.appendManifestToSnapshotArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturns(result1 []manifest.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturns(result1 []schema.Manifest, result2 error) {
 	fake.appendManifestToSnapshotMutex.Lock()
 	defer fake.appendManifestToSnapshotMutex.Unlock()
 	fake.AppendManifestToSnapshotStub = nil
 	fake.appendManifestToSnapshotReturns = struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i int, result1 []manifest.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i int, result1 []schema.Manifest, result2 error) {
 	fake.appendManifestToSnapshotMutex.Lock()
 	defer fake.appendManifestToSnapshotMutex.Unlock()
 	fake.AppendManifestToSnapshotStub = nil
 	if fake.appendManifestToSnapshotReturnsOnCall == nil {
 		fake.appendManifestToSnapshotReturnsOnCall = make(map[int]struct {
-			result1 []manifest.Manifest
+			result1 []schema.Manifest
 			result2 error
 		})
 	}
 	fake.appendManifestToSnapshotReturnsOnCall[i] = struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdges(arg1 *inventory.SyncContext, arg2 []manifest.Manifest) (map[inventory.PromotionEdge]interface{}, error) {
-	var arg2Copy []manifest.Manifest
+func (fake *FakePromoterImplementation) GetPromotionEdges(arg1 *inventory.SyncContext, arg2 []schema.Manifest) (map[inventory.PromotionEdge]interface{}, error) {
+	var arg2Copy []schema.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]manifest.Manifest, len(arg2))
+		arg2Copy = make([]schema.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.getPromotionEdgesMutex.Lock()
 	ret, specificReturn := fake.getPromotionEdgesReturnsOnCall[len(fake.getPromotionEdgesArgsForCall)]
 	fake.getPromotionEdgesArgsForCall = append(fake.getPromotionEdgesArgsForCall, struct {
 		arg1 *inventory.SyncContext
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.GetPromotionEdgesStub
 	fakeReturns := fake.getPromotionEdgesReturns
@@ -434,13 +434,13 @@ func (fake *FakePromoterImplementation) GetPromotionEdgesCallCount() int {
 	return len(fake.getPromotionEdgesArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdgesCalls(stub func(*inventory.SyncContext, []manifest.Manifest) (map[inventory.PromotionEdge]interface{}, error)) {
+func (fake *FakePromoterImplementation) GetPromotionEdgesCalls(stub func(*inventory.SyncContext, []schema.Manifest) (map[inventory.PromotionEdge]interface{}, error)) {
 	fake.getPromotionEdgesMutex.Lock()
 	defer fake.getPromotionEdgesMutex.Unlock()
 	fake.GetPromotionEdgesStub = stub
 }
 
-func (fake *FakePromoterImplementation) GetPromotionEdgesArgsForCall(i int) (*inventory.SyncContext, []manifest.Manifest) {
+func (fake *FakePromoterImplementation) GetPromotionEdgesArgsForCall(i int) (*inventory.SyncContext, []schema.Manifest) {
 	fake.getPromotionEdgesMutex.RLock()
 	defer fake.getPromotionEdgesMutex.RUnlock()
 	argsForCall := fake.getPromotionEdgesArgsForCall[i]
@@ -473,17 +473,17 @@ func (fake *FakePromoterImplementation) GetPromotionEdgesReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetRegistryImageInventory(arg1 *imagepromotera.Options, arg2 []manifest.Manifest) (registry.RegInvImage, error) {
-	var arg2Copy []manifest.Manifest
+func (fake *FakePromoterImplementation) GetRegistryImageInventory(arg1 *imagepromotera.Options, arg2 []schema.Manifest) (registry.RegInvImage, error) {
+	var arg2Copy []schema.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]manifest.Manifest, len(arg2))
+		arg2Copy = make([]schema.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.getRegistryImageInventoryMutex.Lock()
 	ret, specificReturn := fake.getRegistryImageInventoryReturnsOnCall[len(fake.getRegistryImageInventoryArgsForCall)]
 	fake.getRegistryImageInventoryArgsForCall = append(fake.getRegistryImageInventoryArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.GetRegistryImageInventoryStub
 	fakeReturns := fake.getRegistryImageInventoryReturns
@@ -504,13 +504,13 @@ func (fake *FakePromoterImplementation) GetRegistryImageInventoryCallCount() int
 	return len(fake.getRegistryImageInventoryArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetRegistryImageInventoryCalls(stub func(*imagepromotera.Options, []manifest.Manifest) (registry.RegInvImage, error)) {
+func (fake *FakePromoterImplementation) GetRegistryImageInventoryCalls(stub func(*imagepromotera.Options, []schema.Manifest) (registry.RegInvImage, error)) {
 	fake.getRegistryImageInventoryMutex.Lock()
 	defer fake.getRegistryImageInventoryMutex.Unlock()
 	fake.GetRegistryImageInventoryStub = stub
 }
 
-func (fake *FakePromoterImplementation) GetRegistryImageInventoryArgsForCall(i int) (*imagepromotera.Options, []manifest.Manifest) {
+func (fake *FakePromoterImplementation) GetRegistryImageInventoryArgsForCall(i int) (*imagepromotera.Options, []schema.Manifest) {
 	fake.getRegistryImageInventoryMutex.RLock()
 	defer fake.getRegistryImageInventoryMutex.RUnlock()
 	argsForCall := fake.getRegistryImageInventoryArgsForCall[i]
@@ -543,7 +543,7 @@ func (fake *FakePromoterImplementation) GetRegistryImageInventoryReturnsOnCall(i
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotManifests(arg1 *imagepromotera.Options) ([]manifest.Manifest, error) {
+func (fake *FakePromoterImplementation) GetSnapshotManifests(arg1 *imagepromotera.Options) ([]schema.Manifest, error) {
 	fake.getSnapshotManifestsMutex.Lock()
 	ret, specificReturn := fake.getSnapshotManifestsReturnsOnCall[len(fake.getSnapshotManifestsArgsForCall)]
 	fake.getSnapshotManifestsArgsForCall = append(fake.getSnapshotManifestsArgsForCall, struct {
@@ -568,7 +568,7 @@ func (fake *FakePromoterImplementation) GetSnapshotManifestsCallCount() int {
 	return len(fake.getSnapshotManifestsArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotManifestsCalls(stub func(*imagepromotera.Options) ([]manifest.Manifest, error)) {
+func (fake *FakePromoterImplementation) GetSnapshotManifestsCalls(stub func(*imagepromotera.Options) ([]schema.Manifest, error)) {
 	fake.getSnapshotManifestsMutex.Lock()
 	defer fake.getSnapshotManifestsMutex.Unlock()
 	fake.GetSnapshotManifestsStub = stub
@@ -581,28 +581,28 @@ func (fake *FakePromoterImplementation) GetSnapshotManifestsArgsForCall(i int) *
 	return argsForCall.arg1
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotManifestsReturns(result1 []manifest.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) GetSnapshotManifestsReturns(result1 []schema.Manifest, result2 error) {
 	fake.getSnapshotManifestsMutex.Lock()
 	defer fake.getSnapshotManifestsMutex.Unlock()
 	fake.GetSnapshotManifestsStub = nil
 	fake.getSnapshotManifestsReturns = struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) GetSnapshotManifestsReturnsOnCall(i int, result1 []manifest.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) GetSnapshotManifestsReturnsOnCall(i int, result1 []schema.Manifest, result2 error) {
 	fake.getSnapshotManifestsMutex.Lock()
 	defer fake.getSnapshotManifestsMutex.Unlock()
 	fake.GetSnapshotManifestsStub = nil
 	if fake.getSnapshotManifestsReturnsOnCall == nil {
 		fake.getSnapshotManifestsReturnsOnCall = make(map[int]struct {
-			result1 []manifest.Manifest
+			result1 []schema.Manifest
 			result2 error
 		})
 	}
 	fake.getSnapshotManifestsReturnsOnCall[i] = struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
 }
@@ -732,17 +732,17 @@ func (fake *FakePromoterImplementation) MakeProducerFunctionReturnsOnCall(i int,
 	}{result1}
 }
 
-func (fake *FakePromoterImplementation) MakeSyncContext(arg1 *imagepromotera.Options, arg2 []manifest.Manifest) (*inventory.SyncContext, error) {
-	var arg2Copy []manifest.Manifest
+func (fake *FakePromoterImplementation) MakeSyncContext(arg1 *imagepromotera.Options, arg2 []schema.Manifest) (*inventory.SyncContext, error) {
+	var arg2Copy []schema.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]manifest.Manifest, len(arg2))
+		arg2Copy = make([]schema.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.makeSyncContextMutex.Lock()
 	ret, specificReturn := fake.makeSyncContextReturnsOnCall[len(fake.makeSyncContextArgsForCall)]
 	fake.makeSyncContextArgsForCall = append(fake.makeSyncContextArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.MakeSyncContextStub
 	fakeReturns := fake.makeSyncContextReturns
@@ -763,13 +763,13 @@ func (fake *FakePromoterImplementation) MakeSyncContextCallCount() int {
 	return len(fake.makeSyncContextArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) MakeSyncContextCalls(stub func(*imagepromotera.Options, []manifest.Manifest) (*inventory.SyncContext, error)) {
+func (fake *FakePromoterImplementation) MakeSyncContextCalls(stub func(*imagepromotera.Options, []schema.Manifest) (*inventory.SyncContext, error)) {
 	fake.makeSyncContextMutex.Lock()
 	defer fake.makeSyncContextMutex.Unlock()
 	fake.MakeSyncContextStub = stub
 }
 
-func (fake *FakePromoterImplementation) MakeSyncContextArgsForCall(i int) (*imagepromotera.Options, []manifest.Manifest) {
+func (fake *FakePromoterImplementation) MakeSyncContextArgsForCall(i int) (*imagepromotera.Options, []schema.Manifest) {
 	fake.makeSyncContextMutex.RLock()
 	defer fake.makeSyncContextMutex.RUnlock()
 	argsForCall := fake.makeSyncContextArgsForCall[i]
@@ -802,7 +802,7 @@ func (fake *FakePromoterImplementation) MakeSyncContextReturnsOnCall(i int, resu
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) ParseManifests(arg1 *imagepromotera.Options) ([]manifest.Manifest, error) {
+func (fake *FakePromoterImplementation) ParseManifests(arg1 *imagepromotera.Options) ([]schema.Manifest, error) {
 	fake.parseManifestsMutex.Lock()
 	ret, specificReturn := fake.parseManifestsReturnsOnCall[len(fake.parseManifestsArgsForCall)]
 	fake.parseManifestsArgsForCall = append(fake.parseManifestsArgsForCall, struct {
@@ -827,7 +827,7 @@ func (fake *FakePromoterImplementation) ParseManifestsCallCount() int {
 	return len(fake.parseManifestsArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) ParseManifestsCalls(stub func(*imagepromotera.Options) ([]manifest.Manifest, error)) {
+func (fake *FakePromoterImplementation) ParseManifestsCalls(stub func(*imagepromotera.Options) ([]schema.Manifest, error)) {
 	fake.parseManifestsMutex.Lock()
 	defer fake.parseManifestsMutex.Unlock()
 	fake.ParseManifestsStub = stub
@@ -840,43 +840,43 @@ func (fake *FakePromoterImplementation) ParseManifestsArgsForCall(i int) *imagep
 	return argsForCall.arg1
 }
 
-func (fake *FakePromoterImplementation) ParseManifestsReturns(result1 []manifest.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) ParseManifestsReturns(result1 []schema.Manifest, result2 error) {
 	fake.parseManifestsMutex.Lock()
 	defer fake.parseManifestsMutex.Unlock()
 	fake.ParseManifestsStub = nil
 	fake.parseManifestsReturns = struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) ParseManifestsReturnsOnCall(i int, result1 []manifest.Manifest, result2 error) {
+func (fake *FakePromoterImplementation) ParseManifestsReturnsOnCall(i int, result1 []schema.Manifest, result2 error) {
 	fake.parseManifestsMutex.Lock()
 	defer fake.parseManifestsMutex.Unlock()
 	fake.ParseManifestsStub = nil
 	if fake.parseManifestsReturnsOnCall == nil {
 		fake.parseManifestsReturnsOnCall = make(map[int]struct {
-			result1 []manifest.Manifest
+			result1 []schema.Manifest
 			result2 error
 		})
 	}
 	fake.parseManifestsReturnsOnCall[i] = struct {
-		result1 []manifest.Manifest
+		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePromoterImplementation) PrecheckAndExit(arg1 *imagepromotera.Options, arg2 []manifest.Manifest) error {
-	var arg2Copy []manifest.Manifest
+func (fake *FakePromoterImplementation) PrecheckAndExit(arg1 *imagepromotera.Options, arg2 []schema.Manifest) error {
+	var arg2Copy []schema.Manifest
 	if arg2 != nil {
-		arg2Copy = make([]manifest.Manifest, len(arg2))
+		arg2Copy = make([]schema.Manifest, len(arg2))
 		copy(arg2Copy, arg2)
 	}
 	fake.precheckAndExitMutex.Lock()
 	ret, specificReturn := fake.precheckAndExitReturnsOnCall[len(fake.precheckAndExitArgsForCall)]
 	fake.precheckAndExitArgsForCall = append(fake.precheckAndExitArgsForCall, struct {
 		arg1 *imagepromotera.Options
-		arg2 []manifest.Manifest
+		arg2 []schema.Manifest
 	}{arg1, arg2Copy})
 	stub := fake.PrecheckAndExitStub
 	fakeReturns := fake.precheckAndExitReturns
@@ -897,13 +897,13 @@ func (fake *FakePromoterImplementation) PrecheckAndExitCallCount() int {
 	return len(fake.precheckAndExitArgsForCall)
 }
 
-func (fake *FakePromoterImplementation) PrecheckAndExitCalls(stub func(*imagepromotera.Options, []manifest.Manifest) error) {
+func (fake *FakePromoterImplementation) PrecheckAndExitCalls(stub func(*imagepromotera.Options, []schema.Manifest) error) {
 	fake.precheckAndExitMutex.Lock()
 	defer fake.precheckAndExitMutex.Unlock()
 	fake.PrecheckAndExitStub = stub
 }
 
-func (fake *FakePromoterImplementation) PrecheckAndExitArgsForCall(i int) (*imagepromotera.Options, []manifest.Manifest) {
+func (fake *FakePromoterImplementation) PrecheckAndExitArgsForCall(i int) (*imagepromotera.Options, []schema.Manifest) {
 	fake.precheckAndExitMutex.RLock()
 	defer fake.precheckAndExitMutex.RUnlock()
 	argsForCall := fake.precheckAndExitArgsForCall[i]

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -64,7 +64,7 @@ type promoterImplementation interface {
 	PromoteImages(*reg.SyncContext, map[reg.PromotionEdge]interface{}, impl.StreamProducerFunc) error
 
 	// Methods for snapshot mode:
-	GetSnapshotSourceRegistry(*options.Options) (*registry.RegistryContext, error)
+	GetSnapshotSourceRegistry(*options.Options) (*registry.Context, error)
 	GetSnapshotManifests(*options.Options) ([]manifest.Manifest, error)
 	AppendManifestToSnapshot(*options.Options, []manifest.Manifest) ([]manifest.Manifest, error)
 	GetRegistryImageInventory(*options.Options, []manifest.Manifest) (registry.RegInvImage, error)

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -23,6 +23,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	impl "sigs.k8s.io/promo-tools/v3/internal/promoter/image"
 	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 )
@@ -52,21 +54,21 @@ type promoterImplementation interface {
 	// General methods common to all modes of the promoter
 	ValidateOptions(*options.Options) error
 	ActivateServiceAccounts(*options.Options) error
-	PrecheckAndExit(*options.Options, []reg.Manifest) error
+	PrecheckAndExit(*options.Options, []manifest.Manifest) error
 
 	// Methods for promotion mode:
-	ParseManifests(*options.Options) ([]reg.Manifest, error)
-	MakeSyncContext(*options.Options, []reg.Manifest) (*reg.SyncContext, error)
-	GetPromotionEdges(*reg.SyncContext, []reg.Manifest) (map[reg.PromotionEdge]interface{}, error)
+	ParseManifests(*options.Options) ([]manifest.Manifest, error)
+	MakeSyncContext(*options.Options, []manifest.Manifest) (*reg.SyncContext, error)
+	GetPromotionEdges(*reg.SyncContext, []manifest.Manifest) (map[reg.PromotionEdge]interface{}, error)
 	MakeProducerFunction(bool) impl.StreamProducerFunc
 	PromoteImages(*reg.SyncContext, map[reg.PromotionEdge]interface{}, impl.StreamProducerFunc) error
 
 	// Methods for snapshot mode:
-	GetSnapshotSourceRegistry(*options.Options) (*reg.RegistryContext, error)
-	GetSnapshotManifests(*options.Options) ([]reg.Manifest, error)
-	AppendManifestToSnapshot(*options.Options, []reg.Manifest) ([]reg.Manifest, error)
-	GetRegistryImageInventory(*options.Options, []reg.Manifest) (reg.RegInvImage, error)
-	Snapshot(*options.Options, reg.RegInvImage) error
+	GetSnapshotSourceRegistry(*options.Options) (*registry.RegistryContext, error)
+	GetSnapshotManifests(*options.Options) ([]manifest.Manifest, error)
+	AppendManifestToSnapshot(*options.Options, []manifest.Manifest) ([]manifest.Manifest, error)
+	GetRegistryImageInventory(*options.Options, []manifest.Manifest) (registry.RegInvImage, error)
+	Snapshot(*options.Options, registry.RegInvImage) error
 
 	// Methods for image vulnerability scans:
 	ScanEdges(*options.Options, *reg.SyncContext, map[reg.PromotionEdge]interface{}) error

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -23,8 +23,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	impl "sigs.k8s.io/promo-tools/v3/internal/promoter/image"
 	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 )
@@ -54,20 +54,20 @@ type promoterImplementation interface {
 	// General methods common to all modes of the promoter
 	ValidateOptions(*options.Options) error
 	ActivateServiceAccounts(*options.Options) error
-	PrecheckAndExit(*options.Options, []manifest.Manifest) error
+	PrecheckAndExit(*options.Options, []schema.Manifest) error
 
 	// Methods for promotion mode:
-	ParseManifests(*options.Options) ([]manifest.Manifest, error)
-	MakeSyncContext(*options.Options, []manifest.Manifest) (*reg.SyncContext, error)
-	GetPromotionEdges(*reg.SyncContext, []manifest.Manifest) (map[reg.PromotionEdge]interface{}, error)
+	ParseManifests(*options.Options) ([]schema.Manifest, error)
+	MakeSyncContext(*options.Options, []schema.Manifest) (*reg.SyncContext, error)
+	GetPromotionEdges(*reg.SyncContext, []schema.Manifest) (map[reg.PromotionEdge]interface{}, error)
 	MakeProducerFunction(bool) impl.StreamProducerFunc
 	PromoteImages(*reg.SyncContext, map[reg.PromotionEdge]interface{}, impl.StreamProducerFunc) error
 
 	// Methods for snapshot mode:
 	GetSnapshotSourceRegistry(*options.Options) (*registry.Context, error)
-	GetSnapshotManifests(*options.Options) ([]manifest.Manifest, error)
-	AppendManifestToSnapshot(*options.Options, []manifest.Manifest) ([]manifest.Manifest, error)
-	GetRegistryImageInventory(*options.Options, []manifest.Manifest) (registry.RegInvImage, error)
+	GetSnapshotManifests(*options.Options) ([]schema.Manifest, error)
+	AppendManifestToSnapshot(*options.Options, []schema.Manifest) ([]schema.Manifest, error)
+	GetRegistryImageInventory(*options.Options, []schema.Manifest) (registry.RegInvImage, error)
 	Snapshot(*options.Options, registry.RegInvImage) error
 
 	// Methods for image vulnerability scans:

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -32,6 +32,8 @@ import (
 
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/audit"
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/gcloud"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 	"sigs.k8s.io/promo-tools/v3/internal/version"
@@ -326,7 +328,7 @@ func (t *E2ETest) clearRepositories() error {
 	// We need a SyncContext to clear the repos. That's it. The actual
 	// promotions will be done by the cip binary, not this tool.
 	sc, err := reg.MakeSyncContext(
-		[]reg.Manifest{
+		[]manifest.Manifest{
 			{Registries: t.Registries},
 		},
 		10,
@@ -884,7 +886,7 @@ func checkCommand(cmd []string) error {
 
 func clearRepository(regName image.Registry, sc *reg.SyncContext) {
 	mkDeletionCmd := func(
-		dest reg.RegistryContext,
+		dest registry.RegistryContext,
 		imageName image.Name,
 		digest image.Digest,
 	) stream.Producer {
@@ -957,13 +959,13 @@ func checkLogs(projectID, uuid string, patterns []string) error {
 // auditor running in Cloud Run (whether the state change is VERIFIED or
 // REJECTED).
 type E2ETest struct {
-	Name        string                `yaml:"name,omitempty"`
-	Registries  []reg.RegistryContext `yaml:"registries,omitempty"`
-	ManifestDir string                `yaml:"manifestDir,omitempty"`
-	SetupCip    []string              `yaml:"setupCip,omitempty"`
-	SetupExtra  [][]string            `yaml:"setupExtra,omitempty"`
-	Mutations   [][]string            `yaml:"mutations,omitempty"`
-	LogMatch    []string              `yaml:"logMatch,omitempty"`
+	Name        string                     `yaml:"name,omitempty"`
+	Registries  []registry.RegistryContext `yaml:"registries,omitempty"`
+	ManifestDir string                     `yaml:"manifestDir,omitempty"`
+	SetupCip    []string                   `yaml:"setupCip,omitempty"`
+	SetupExtra  [][]string                 `yaml:"setupExtra,omitempty"`
+	Mutations   [][]string                 `yaml:"mutations,omitempty"`
+	LogMatch    []string                   `yaml:"logMatch,omitempty"`
 }
 
 // E2ETests is an array of E2ETest.

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -886,7 +886,7 @@ func checkCommand(cmd []string) error {
 
 func clearRepository(regName image.Registry, sc *reg.SyncContext) {
 	mkDeletionCmd := func(
-		dest registry.RegistryContext,
+		dest registry.Context,
 		imageName image.Name,
 		digest image.Digest,
 	) stream.Producer {
@@ -959,13 +959,13 @@ func checkLogs(projectID, uuid string, patterns []string) error {
 // auditor running in Cloud Run (whether the state change is VERIFIED or
 // REJECTED).
 type E2ETest struct {
-	Name        string                     `yaml:"name,omitempty"`
-	Registries  []registry.RegistryContext `yaml:"registries,omitempty"`
-	ManifestDir string                     `yaml:"manifestDir,omitempty"`
-	SetupCip    []string                   `yaml:"setupCip,omitempty"`
-	SetupExtra  [][]string                 `yaml:"setupExtra,omitempty"`
-	Mutations   [][]string                 `yaml:"mutations,omitempty"`
-	LogMatch    []string                   `yaml:"logMatch,omitempty"`
+	Name        string             `yaml:"name,omitempty"`
+	Registries  []registry.Context `yaml:"registries,omitempty"`
+	ManifestDir string             `yaml:"manifestDir,omitempty"`
+	SetupCip    []string           `yaml:"setupCip,omitempty"`
+	SetupExtra  [][]string         `yaml:"setupExtra,omitempty"`
+	Mutations   [][]string         `yaml:"mutations,omitempty"`
+	LogMatch    []string           `yaml:"logMatch,omitempty"`
 }
 
 // E2ETests is an array of E2ETest.

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -32,8 +32,8 @@ import (
 
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/audit"
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/gcloud"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 	"sigs.k8s.io/promo-tools/v3/internal/version"
@@ -328,7 +328,7 @@ func (t *E2ETest) clearRepositories() error {
 	// We need a SyncContext to clear the repos. That's it. The actual
 	// promotions will be done by the cip binary, not this tool.
 	sc, err := reg.MakeSyncContext(
-		[]manifest.Manifest{
+		[]schema.Manifest{
 			{Registries: t.Registries},
 		},
 		10,

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -33,6 +33,8 @@ import (
 	"sigs.k8s.io/release-utils/command"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/gcloud"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 	"sigs.k8s.io/promo-tools/v3/internal/version"
@@ -119,9 +121,9 @@ func main() {
 
 func checkSnapshot(
 	repo image.Registry,
-	expected []reg.Image,
+	expected []registry.Image,
 	repoRoot string,
-	rcs []reg.RegistryContext,
+	rcs []registry.RegistryContext,
 ) error {
 	got, err := getSnapshot(
 		repoRoot,
@@ -191,7 +193,7 @@ func runPromotion(repoRoot string, t *E2ETest) error {
 	return cmd.RunSuccess()
 }
 
-func extractSvcAcc(registry image.Registry, rcs []reg.RegistryContext) string {
+func extractSvcAcc(registry image.Registry, rcs []registry.RegistryContext) string {
 	for _, r := range rcs {
 		if r.Name == registry {
 			return r.ServiceAccount
@@ -204,8 +206,8 @@ func extractSvcAcc(registry image.Registry, rcs []reg.RegistryContext) string {
 func getSnapshot(
 	repoRoot string,
 	registry image.Registry,
-	rcs []reg.RegistryContext,
-) ([]reg.Image, error) {
+	rcs []registry.RegistryContext,
+) ([]registry.Image, error) {
 	// TODO: Consider setting flag names in `cip` instead
 	invocation := []string{
 		"run",
@@ -242,7 +244,7 @@ func getSnapshot(
 		return nil, err
 	}
 
-	images := make([]reg.Image, 0)
+	images := make(registry.Images, 0)
 	if err := yaml.UnmarshalStrict(stdout.Bytes(), &images); err != nil {
 		return nil, err
 	}
@@ -254,7 +256,7 @@ func (t *E2ETest) clearRepositories() error {
 	// We need a SyncContext to clear the repos. That's it. The actual
 	// promotions will be done by the cip binary, not this tool.
 	sc, err := reg.MakeSyncContext(
-		[]reg.Manifest{
+		[]manifest.Manifest{
 			{Registries: t.Registries},
 		},
 		10,
@@ -282,7 +284,7 @@ func (t *E2ETest) clearRepositories() error {
 
 func clearRepository(regName image.Registry, sc *reg.SyncContext) {
 	mkDeletionCmd := func(
-		dest reg.RegistryContext,
+		dest registry.RegistryContext,
 		imageName image.Name,
 		digest image.Digest) stream.Producer {
 		var sp stream.Subprocess
@@ -302,10 +304,10 @@ func clearRepository(regName image.Registry, sc *reg.SyncContext) {
 // promoter manifest, and the before/after snapshots of all repositories that it
 // cares about.
 type E2ETest struct {
-	Name       string                `yaml:"name,omitempty"`
-	Registries []reg.RegistryContext `yaml:"registries,omitempty"`
-	Invocation []string              `yaml:"invocation,omitempty"`
-	Snapshots  []RegistrySnapshot    `yaml:"snapshots,omitempty"`
+	Name       string                     `yaml:"name,omitempty"`
+	Registries []registry.RegistryContext `yaml:"registries,omitempty"`
+	Invocation []string                   `yaml:"invocation,omitempty"`
+	Snapshots  []RegistrySnapshot         `yaml:"snapshots,omitempty"`
 }
 
 // E2ETests is an array of E2ETest.
@@ -314,9 +316,9 @@ type E2ETests []E2ETest
 // RegistrySnapshot is the snapshot of a registry. It is basically the key/value
 // pair out of the reg.MasterInventory type (RegistryName + []Image).
 type RegistrySnapshot struct {
-	Name   image.Registry `yaml:"name,omitempty"`
-	Before []reg.Image    `yaml:"before,omitempty"`
-	After  []reg.Image    `yaml:"after,omitempty"`
+	Name   image.Registry  `yaml:"name,omitempty"`
+	Before registry.Images `yaml:"before,omitempty"`
+	After  registry.Images `yaml:"after,omitempty"`
 }
 
 func readE2ETests(filePath string) (E2ETests, error) {

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -123,7 +123,7 @@ func checkSnapshot(
 	repo image.Registry,
 	expected []registry.Image,
 	repoRoot string,
-	rcs []registry.RegistryContext,
+	rcs []registry.Context,
 ) error {
 	got, err := getSnapshot(
 		repoRoot,
@@ -193,10 +193,10 @@ func runPromotion(repoRoot string, t *E2ETest) error {
 	return cmd.RunSuccess()
 }
 
-func extractSvcAcc(registry image.Registry, rcs []registry.RegistryContext) string {
-	for _, r := range rcs {
-		if r.Name == registry {
-			return r.ServiceAccount
+func extractSvcAcc(r image.Registry, rcs []registry.Context) string {
+	for _, regCtx := range rcs {
+		if regCtx.Name == r {
+			return regCtx.ServiceAccount
 		}
 	}
 
@@ -205,8 +205,8 @@ func extractSvcAcc(registry image.Registry, rcs []registry.RegistryContext) stri
 
 func getSnapshot(
 	repoRoot string,
-	registry image.Registry,
-	rcs []registry.RegistryContext,
+	registryName image.Registry,
+	rcs []registry.Context,
 ) ([]registry.Image, error) {
 	// TODO: Consider setting flag names in `cip` instead
 	invocation := []string{
@@ -217,10 +217,10 @@ func getSnapshot(
 			kpromoMain,
 		),
 		"cip",
-		"--snapshot=" + string(registry),
+		"--snapshot=" + string(registryName),
 	}
 
-	svcAcc := extractSvcAcc(registry, rcs)
+	svcAcc := extractSvcAcc(registryName, rcs)
 	if len(svcAcc) > 0 {
 		invocation = append(invocation, "--snapshot-service-account="+svcAcc)
 	}
@@ -284,7 +284,7 @@ func (t *E2ETest) clearRepositories() error {
 
 func clearRepository(regName image.Registry, sc *reg.SyncContext) {
 	mkDeletionCmd := func(
-		dest registry.RegistryContext,
+		dest registry.Context,
 		imageName image.Name,
 		digest image.Digest) stream.Producer {
 		var sp stream.Subprocess
@@ -304,10 +304,10 @@ func clearRepository(regName image.Registry, sc *reg.SyncContext) {
 // promoter manifest, and the before/after snapshots of all repositories that it
 // cares about.
 type E2ETest struct {
-	Name       string                     `yaml:"name,omitempty"`
-	Registries []registry.RegistryContext `yaml:"registries,omitempty"`
-	Invocation []string                   `yaml:"invocation,omitempty"`
-	Snapshots  []RegistrySnapshot         `yaml:"snapshots,omitempty"`
+	Name       string             `yaml:"name,omitempty"`
+	Registries []registry.Context `yaml:"registries,omitempty"`
+	Invocation []string           `yaml:"invocation,omitempty"`
+	Snapshots  []RegistrySnapshot `yaml:"snapshots,omitempty"`
 }
 
 // E2ETests is an array of E2ETest.

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -33,8 +33,8 @@ import (
 	"sigs.k8s.io/release-utils/command"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
-	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/manifest"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
+	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/gcloud"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
 	"sigs.k8s.io/promo-tools/v3/internal/version"
@@ -256,7 +256,7 @@ func (t *E2ETest) clearRepositories() error {
 	// We need a SyncContext to clear the repos. That's it. The actual
 	// promotions will be done by the cip binary, not this tool.
 	sc, err := reg.MakeSyncContext(
-		[]manifest.Manifest{
+		[]schema.Manifest{
 			{Registries: t.Registries},
 		},
 		10,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Continues https://github.com/kubernetes-sigs/promo-tools/pull/511, https://github.com/kubernetes-sigs/promo-tools/pull/509, https://github.com/kubernetes-sigs/promo-tools/pull/497.

- Initial breakout of inventory logic into separate packages
- dockerregistry: Move manifest, context, registry logic
- Fixup references to internal/ packages
- Post-refactor lint warning fixups
- dockerregistry: Rename `manifest` package to `schema`

Rationale:

When this repo was in its infancy, there were two workflows: image and file promotion
Each workflow had a different package layout and while we've moved some things around since then, that is still technically true.

In an effort to limit the surface area we're unnecessarily exposing to consumers, I've done two things:

- a while back: move the original image promotion packages to `legacy/`
- yesterday: move the `legacy/` package to `internal/legacy/`, which prevents it from being importable

If you run `scc` on this repo, you'll see the following:

```console
❯ scc --by-file -s complexity
───────────────────────────────────────────────────────────────────────────────
Language                 Files     Lines   Blanks  Comments     Code Complexity
───────────────────────────────────────────────────────────────────────────────
Go                          83     20963     2171      3159    15633       1664
───────────────────────────────────────────────────────────────────────────────
~y/dockerregistry/inventory.go      3129      408       508     2213        470
~ip-auditor/cip-auditor-e2e.go       992      124       133      735        113
~ke_promoter_implementation.go      1574      124        16     1434        111
cmd/kpromo/cmd/pr/pr.go              397       57        57      283         74
image/manifest/manifest.go           394       53        68      273         67
promobot/promotefiles.go             324       55        54      215         58
~gacy/dockerregistry/checks.go       467       41       115      311         51
promoter/image/promoter.go           246       48        42      156         46
test-e2e/cip/e2e.go                  342       55        37      250         43
promoter/file/filestore.go           274       41        28      205         43
~ernal/legacy/audit/auditor.go       394       59       105      230         42
cmd/kpromo/cmd/gh/gh.go              251       38        20      193         33
~kerregistry/inventory_test.go      3548      137        89     3322         32
~al/promoter/image/snapshot.go       184       24        39      121         28
api/files/validation.go              108       20        20       68         27
~/legacy/audit/auditor_test.go       961       48        39      874         23
cmd/count-requests/main.go           204       18        35      151         23
promoter/file/gcs.go                 146       24        21      101         22
~efakes/fake_sync_filestore.go       291       24        16      251         20
~/legacy/remotemanifest/git.go       140       22        29       89         20
~romo/cmd/manifest/validate.go       145       13        21      111         19
image/image.go                       157       24        41       92         18
promoter/file/file.go                116       18        26       72         18
~ternal/promoter/image/impl.go       126       17        31       78         18
~moter/image/imagepromotion.go       121       11        33       77         16
internal/legacy/cli/audit.go         115       19        22       74         15
api/files/manifest_test.go           155        7        19      129         15
promobot/hash_test.go                 76       12        23       41         14
~ternal/legacy/gcloud/token.go       108       14        28       66         12
promobot/hash.go                      92       14        26       52         12
~oter/image/options/options.go       119       25        47       47         12
promoter/file/manifest.go             94       12        24       58         12
~reqcounter/reqcounter_test.go       252       14        60      178         11
~ilefakes/fake_sync_file_op.go       128       13        16       99         10
~age/manifest/manifest_test.go       321       17        21      283          9
cmd/verify-gcr-quota/main.go         119       16        32       71          8
~/kpromo/cmd/manifest/files.go        96       19        20       57          8
~gacy/reqcounter/reqcounter.go       189       23        55      111          7
~nternal/legacy/stream/http.go        83       12        26       45          6
~ternal/promoter/image/sign.go        84       12        24       48          6
~l/legacy/stream/subprocess.go        60        6        24       30          6
~ernal/legacy/container/set.go        59        6        21       32          6
~promobot/readmanifest_test.go        69        7        15       47          5
internal/legacy/json/json.go          47        6        20       21          5
~/legacy/dockerregistry/set.go       151       29        34       88          5
internal/legacy/cli/run.go            56        9        22       25          5
gh2gcs/gh2gcs.go                      85       14        25       46          5
~dockerregistry/checks_test.go       573       23        26      524          4
cmd/kpromo/cmd/mm/mm.go              105       12        16       77          4
~kpromo/cmd/version/version.go        69       11        16       42          3
promoter/file/token.go                50        8        17       25          2
~ernal/legacy/logclient/gcp.go        79       12        27       40          2
internal/version/version.go           80        9        17       54          2
~romoter/image/securityscan.go        46        4        17       25          2
~egacy/signals/signals_test.go       158        7        42      109          2
~nal/legacy/signals/signals.go        91        8        36       47          2
image/image_test.go                  237       21        18      198          2
api/files/manifest.go                 65        8        32       25          2
~internal/legacy/report/gcp.go        46        6        16       24          2
cmd/kpromo/cmd/root.go                90       11        20       59          2
~omoter/file/filestore_test.go       118        7        15       96          2
~egacy/dockerregistry/types.go       460       62       198      200          1
cmd/kpromo/cmd/cip/cip.go            215       25        23      167          1
~rnal/legacy/logclient/fake.go        76       13        25       38          0
cmd/kpromo/main.go                    25        4        16        5          0
cmd/kpromo/cmd/run/run.go             29        3        16       10          0
cmd/kpromo/cmd/run/files.go           92       17        20       55          0
~ternal/legacy/report/types.go        41        5        24       12          0
~legacy/remotemanifest/fake.go        41        7        19       15          0
~ternal/legacy/stream/types.go        60        7        31       22          0
internal/legacy/cli/root.go           19        2        16        1          0
internal/tools.go                     25        4        17        4          0
~egacy/remotemanifest/types.go        27        3        17        7          0
~ernal/version/version_test.go        34        5        15       14          0
cmd/kpromo/cmd/cip/audit.go           84       11        17       56          0
~romo/cmd/manifest/manifest.go        29        3        16       10          0
~nternal/legacy/stream/fake.go        43        5        20       18          0
~nternal/legacy/audit/types.go        61        7        24       30          0
promoter/file/interfaces.go           27        4        18        5          0
~nal/legacy/logclient/types.go        43        5        19       19          0
types/image/image.go                  33        5        23        5          0
~nternal/legacy/report/fake.go        54        9        21       24          0
~cy/timewrapper/timewrapper.go        49        9        22       18          0
───────────────────────────────────────────────────────────────────────────────
Shell                       16       921      120       354      447         45
───────────────────────────────────────────────────────────────────────────────
go_with_version.sh                    56        9        19       28         10
hack/init-buildx.sh                   71        7        45       19          9
~/golden-images/push-golden.sh        92       14        31       47          6
workspace_status.sh                   74       10        26       38          6
hack/test-go.sh                       78       13        20       45          4
hack/verify-archives.sh               76       10        33       33          3
hack/verify-golangci-lint.sh          37        6        14       17          2
hack/local-audit.sh                   68       12        23       33          2
hack/cip-image.sh                    156        6        25      125          1
hack/verify-dependencies.sh           42        7        17       18          1
hack/verify-boilerplate.sh            33        5        14       14          1
hack/verify-go-mod.sh                 22        3        14        5          0
hack/verify-mocks.sh                  22        3        14        5          0
~/entrypoint-from-container.sh        36        6        22        8          0
hack/verify-build.sh                  21        3        14        4          0
~-entrypoint-from-container.sh        37        6        23        8          0
───────────────────────────────────────────────────────────────────────────────
Makefile                     1       178       41        22      115          4
───────────────────────────────────────────────────────────────────────────────
Makefile                             178       41        22      115          4
───────────────────────────────────────────────────────────────────────────────
Dockerfile                   1        71       16        32       23          0
───────────────────────────────────────────────────────────────────────────────
Dockerfile                            71       16        32       23          0
───────────────────────────────────────────────────────────────────────────────
JSON                         1        11        0         0       11          0
───────────────────────────────────────────────────────────────────────────────
docker/config.json                    11        0         0       11          0
───────────────────────────────────────────────────────────────────────────────
License                      1       202       33         0      169          0
───────────────────────────────────────────────────────────────────────────────
LICENSE                              202       33         0      169          0
───────────────────────────────────────────────────────────────────────────────
Markdown                    17      1185      292         0      893          0
───────────────────────────────────────────────────────────────────────────────
code-of-conduct.md                     3        1         0        2          0
README.md                            120       34         0       86          0
CONTRIBUTING.md                       28        8         0       20          0
test-e2e/README.md                    51       16         0       35          0
docs/image-promotion.md              283       58         0      225          0
docs/github-promotion.md              86       24         0       62          0
~thub/PULL_REQUEST_TEMPLATE.md        57       16         0       41          0
~/ISSUE_TEMPLATE/bug-report.md        26        9         0       17          0
docs/checks.md                       136       20         0      116          0
docs/development.md                  113       28         0       85          0
~hub/ISSUE_TEMPLATE/feature.md        11        3         0        8          0
.github/SECURITY.md                   14        5         0        9          0
docs/file-promotion.md                96       26         0       70          0
~cs/promotion-pull-requests.md       146       42         0      104          0
cmd/cip-mm/README.md                   7        2         0        5          0
~ee-structure-nested/README.md         5        0         0        5          0
~d-prefix-is-ignored/README.md         3        0         0        3          0
───────────────────────────────────────────────────────────────────────────────
Plain Text                   9        91       12         0       79          0
───────────────────────────────────────────────────────────────────────────────
~oilerplate/boilerplate.sh.txt        14        1         0       13          0
~te/boilerplate.generatego.txt        16        4         0       12          0
~oilerplate/boilerplate.py.txt        14        1         0       13          0
~late/boilerplate.Makefile.txt        14        1         0       13          0
~te/boilerplate.Dockerfile.txt        14        1         0       13          0
~oilerplate/boilerplate.go.txt        16        4         0       12          0
~stdata/empty/non-manifest.txt         1        0         0        1          0
~romDir/empty/non-manifest.txt         1        0         0        1          0
~nvalid/empty/non-manifest.txt         1        0         0        1          0
───────────────────────────────────────────────────────────────────────────────
YAML                        82      1030       30       118      882          0
───────────────────────────────────────────────────────────────────────────────
container-structure.yaml               5        0         0        5          0
dependencies.yaml                     65        8        10       47          0
.golangci.yml                        186        5        46      135          0
cloudbuild.yaml                       48        7         5       36          0
.github/dependabot.yml                11        0         0       11          0
~/testdata/files-manifest.yaml         7        0         0        7          0
~le/filepromoter-manifest.yaml         4        0         0        4          0
~/manifests/onefile/files.yaml         7        0         0        7          0
~es/filepromoter-manifest.yaml         4        0         0        4          0
~ests/manyfiles/files/red.yaml         4        1         0        3          0
~ts/manyfiles/files/green.yaml         4        1         0        3          0
~s/manifests/project2/red.yaml         4        1         0        3          0
~t2/filepromoter-manifest.yaml         4        0         0        4          0
~ta/expected/manyprojects.yaml        22        0         0       22          0
~tdata/expected/manyfiles.yaml        11        0         0       11          0
~estdata/expected/onefile.yaml        11        0         0       11          0
~sts/manyfiles/files/blue.yaml         4        1         0        3          0
~t1/filepromoter-manifest.yaml         4        0         0        4          0
~s/manifests/project1/red.yaml         4        1         0        3          0
~manifests/project1/green.yaml         4        1         0        3          0
~/manifests/project1/blue.yaml         4        1         0        3          0
~st-e2e/cip-auditor/tests.yaml       126        0        50       76          0
~ts/foo/promoter-manifest.yaml         6        0         0        6          0
~nifest/images/foo/images.yaml         5        0         1        4          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~manifests/project2/green.yaml         4        1         0        3          0
~/manifests/project2/blue.yaml         4        1         0        3          0
~ts/foo/promoter-manifest.yaml         6        0         0        6          0
~ingleton/images/a/images.yaml         3        0         0        3          0
test-e2e/cip/tests.yaml               79        0         4       75          0
~sanity/promoter-manifest.yaml        21        1         0       20          0
~ests/d/promoter-manifest.yaml        10        0         0       10          0
~ingleton/images/a/images.yaml         3        0         0        3          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~-rebases/images/a/images.yaml         3        0         0        3          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ts/foo/promoter-manifest.yaml        11        0         0       11          0
~tructure/images/a/images.yaml         3        0         0        3          0
~fest/b/promoter-manifest.yaml        10        0         0       10          0
~sic-thin/images/c/images.yaml         3        0         0        3          0
~e-thin/images/foo/images.yaml         9        0         0        9          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~gistries/images/b/images.yaml         3        0         0        3          0
~gistries/images/a/images.yaml         3        0         0        3          0
~e-digest/images/b/images.yaml         3        0         0        3          0
~-rebases/images/a/images.yaml         3        0         0        3          0
~prefix/images/foo/images.yaml         5        0         1        4          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~e-digest/images/a/images.yaml         3        0         0        3          0
~ests/b/promoter-manifest.yaml        11        0         0       11          0
~-ignored/images/a/images.yaml         3        0         0        3          0
~/basic/images/foo/images.yaml         9        0         0        9          0
~ts/bar/promoter-manifest.yaml         6        0         0        6          0
~sic-thin/images/d/images.yaml         3        0         0        3          0
~sic-thin/images/a/images.yaml         3        0         0        3          0
~sic-thin/images/b/images.yaml         3        0         0        3          0
~/basic/images/bar/images.yaml         4        0         0        4          0
~t-digest/images/b/images.yaml         4        0         1        3          0
~ts/foo/promoter-manifest.yaml         6        0         0        6          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ts/bar/promoter-manifest.yaml        11        0         0       11          0
~-rebases/images/b/images.yaml         3        0         0        3          0
~ests/a/promoter-manifest.yaml        11        0         0       11          0
~-rebases/images/b/images.yaml         3        0         0        3          0
~e-thin/images/bar/images.yaml         4        0         0        4          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ests/c/promoter-manifest.yaml        11        0         0       11          0
~t-digest/images/a/images.yaml         3        0         0        3          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ingleton/images/a/images.yaml         3        0         0        3          0
~e-nested/images/a/images.yaml         3        0         0        3          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ts/b/c/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~anifests/images/c/images.yaml         3        0         0        3          0
───────────────────────────────────────────────────────────────────────────────
gitignore                    1        17        3         4       10          0
───────────────────────────────────────────────────────────────────────────────
.gitignore                            17        3         4       10          0
───────────────────────────────────────────────────────────────────────────────
Total                      212     24669     2718      3689    18262       1713
───────────────────────────────────────────────────────────────────────────────
Estimated Cost to Develop (organic) $570,454
Estimated Schedule Effort (organic) 11.111638 months
Estimated People Required (organic) 4.560988
───────────────────────────────────────────────────────────────────────────────
Processed 715894 bytes, 0.716 megabytes (SI)
───────────────────────────────────────────────────────────────────────────────
```

The highlight is that the `inventory` package has the most lines of code and highest complexity.

Technique:

Given `inventory.go` (and `dockerregistry` overall) is difficult to reason about, it made sense to use this as the basis of a refactor.

If we look at this in terms of personas, there are roughly two (with a little overlap):

- Operator: Release Engineering subproject, responsible for maintaining the actual artifact promotion
- User: Anyone else leveraging tools in the repo to create artifact promotion requests (PRs)

So this PR looks at the user lens, targeting logic that is used in `https://github.com/kubernetes-sigs/promo-tools/tree/main/cmd/kpromo` (and its dependencies) for refactor.

Here we've created a few nested packages within `dockerregistry/inventory` that assist with creating/modifying image manifests.

Before:

```console
❯ tree -L 2 internal/legacy/dockerregistry
internal/legacy/dockerregistry
├── checks.go
├── checks_test.go
├── inventory.go
├── inventory_test
│   ├── TestParseThinManifestsFromDir
│   └── TestValidateThinManifestsFromDir
├── inventory_test.go
├── set.go
└── types.go
```

After:

```console
❯ tree -L 2 internal/legacy/dockerregistry
internal/legacy/dockerregistry
├── checks.go
├── checks_test.go
├── inventory.go
├── inventory_test
│   ├── TestParseThinManifestsFromDir
│   └── TestValidateThinManifestsFromDir
├── inventory_test.go
├── registry
│   ├── context.go # Registry contexts/clients
│   ├── registry.go # Registry paradigms, like images, digests, tags
│   └── set.go # Set logic for registry paradigms
├── schema
│   └── manifest.go # Operations on promotion manifests
└── types.go
```

I've opted to not pull tests out of `inventory_test.go`, because:

1. They're already their own package (`inventory_test`) which imports the new packages
2. The new packages are subject to change as we move further into refactoring, so it'd essentially be busy work right now

And now, for a look at the new complexity numbers:

```console
❯ scc --by-file -s complexity
───────────────────────────────────────────────────────────────────────────────
Language                 Files     Lines   Blanks  Comments     Code Complexity
───────────────────────────────────────────────────────────────────────────────
Go                          86     21068     2181      3203    15684       1664
───────────────────────────────────────────────────────────────────────────────
~y/dockerregistry/inventory.go      2360      289       406     1665        323
~ip-auditor/cip-auditor-e2e.go       994      124       133      737        113
~ke_promoter_implementation.go      1576      124        16     1436        111
~erregistry/schema/manifest.go       524       79       119      326         93
cmd/kpromo/cmd/pr/pr.go              397       57        57      283         74
image/manifest/manifest.go           396       53        68      275         67
promobot/promotefiles.go             324       55        54      215         58
~registry/registry/registry.go       457       64       110      283         53
~gacy/dockerregistry/checks.go       468       41       115      312         51
promoter/image/promoter.go           248       48        42      158         46
test-e2e/cip/e2e.go                  344       55        37      252         43
promoter/file/filestore.go           274       41        28      205         43
~ernal/legacy/audit/auditor.go       396       59       105      232         42
cmd/kpromo/cmd/gh/gh.go              251       38        20      193         33
~kerregistry/inventory_test.go      3550      137        89     3324         32
~al/promoter/image/snapshot.go       186       24        39      123         28
api/files/validation.go              108       20        20       68         27
cmd/count-requests/main.go           204       18        35      151         23
~/legacy/audit/auditor_test.go       963       48        39      876         23
promoter/file/gcs.go                 146       24        21      101         22
~/legacy/remotemanifest/git.go       140       22        29       89         20
~efakes/fake_sync_filestore.go       291       24        16      251         20
~romo/cmd/manifest/validate.go       145       13        21      111         19
promoter/file/file.go                116       18        26       72         18
~ternal/promoter/image/impl.go       128       17        31       80         18
image/image.go                       157       24        41       92         18
~moter/image/imagepromotion.go       123       11        33       79         16
internal/legacy/cli/audit.go         115       19        22       74         15
api/files/manifest_test.go           155        7        19      129         15
promobot/hash_test.go                 76       12        23       41         14
promoter/file/manifest.go             94       12        24       58         12
promobot/hash.go                      92       14        26       52         12
~ternal/legacy/gcloud/token.go       108       14        28       66         12
~oter/image/options/options.go       119       25        47       47         12
~reqcounter/reqcounter_test.go       252       14        60      178         11
~ilefakes/fake_sync_file_op.go       128       13        16       99         10
~age/manifest/manifest_test.go       322       17        21      284          9
cmd/verify-gcr-quota/main.go         119       16        32       71          8
~/kpromo/cmd/manifest/files.go        96       19        20       57          8
~gacy/reqcounter/reqcounter.go       189       23        55      111          7
~nternal/legacy/stream/http.go        83       12        26       45          6
~l/legacy/stream/subprocess.go        60        6        24       30          6
~ternal/promoter/image/sign.go        84       12        24       48          6
~ernal/legacy/container/set.go        59        6        21       32          6
internal/legacy/json/json.go          47        6        20       21          5
gh2gcs/gh2gcs.go                      85       14        25       46          5
internal/legacy/cli/run.go            56        9        22       25          5
~ockerregistry/registry/set.go       151       29        34       88          5
~promobot/readmanifest_test.go        69        7        15       47          5
cmd/kpromo/cmd/mm/mm.go              105       12        16       77          4
~dockerregistry/checks_test.go       575       23        26      526          4
~kpromo/cmd/version/version.go        69       11        16       42          3
cmd/kpromo/cmd/root.go                90       11        20       59          2
promoter/file/token.go                50        8        17       25          2
~romoter/image/securityscan.go        46        4        17       25          2
~omoter/file/filestore_test.go       118        7        15       96          2
image/image_test.go                  237       21        18      198          2
~nal/legacy/signals/signals.go        91        8        36       47          2
api/files/manifest.go                 65        8        32       25          2
~ernal/legacy/logclient/gcp.go        79       12        27       40          2
~rregistry/registry/context.go        45        6        18       21          2
~egacy/signals/signals_test.go       158        7        42      109          2
~internal/legacy/report/gcp.go        46        6        16       24          2
internal/version/version.go           80        9        17       54          2
cmd/kpromo/cmd/cip/cip.go            215       25        23      167          1
~egacy/remotemanifest/types.go        25        3        17        5          0
~nternal/legacy/report/fake.go        54        9        21       24          0
~rnal/legacy/logclient/fake.go        76       13        25       38          0
internal/legacy/cli/root.go           19        2        16        1          0
~egacy/dockerregistry/types.go       285       42        97      146          0
~romo/cmd/manifest/manifest.go        29        3        16       10          0
cmd/kpromo/main.go                    25        4        16        5          0
~ternal/legacy/stream/types.go        60        7        31       22          0
cmd/kpromo/cmd/run/run.go             29        3        16       10          0
cmd/kpromo/cmd/run/files.go           92       17        20       55          0
~ernal/version/version_test.go        34        5        15       14          0
~cy/timewrapper/timewrapper.go        49        9        22       18          0
promoter/file/interfaces.go           27        4        18        5          0
types/image/image.go                  33        5        23        5          0
cmd/kpromo/cmd/cip/audit.go           84       11        17       56          0
~ternal/legacy/report/types.go        41        5        24       12          0
~nal/legacy/logclient/types.go        43        5        19       19          0
~nternal/legacy/audit/types.go        62        7        24       31          0
internal/tools.go                     25        4        17        4          0
~legacy/remotemanifest/fake.go        39        7        19       13          0
~nternal/legacy/stream/fake.go        43        5        20       18          0
───────────────────────────────────────────────────────────────────────────────
Shell                       16       921      120       354      447         45
───────────────────────────────────────────────────────────────────────────────
go_with_version.sh                    56        9        19       28         10
hack/init-buildx.sh                   71        7        45       19          9
workspace_status.sh                   74       10        26       38          6
~/golden-images/push-golden.sh        92       14        31       47          6
hack/test-go.sh                       78       13        20       45          4
hack/verify-archives.sh               76       10        33       33          3
hack/local-audit.sh                   68       12        23       33          2
hack/verify-golangci-lint.sh          37        6        14       17          2
hack/verify-boilerplate.sh            33        5        14       14          1
hack/verify-dependencies.sh           42        7        17       18          1
hack/cip-image.sh                    156        6        25      125          1
hack/verify-go-mod.sh                 22        3        14        5          0
~/entrypoint-from-container.sh        36        6        22        8          0
~-entrypoint-from-container.sh        37        6        23        8          0
hack/verify-build.sh                  21        3        14        4          0
hack/verify-mocks.sh                  22        3        14        5          0
───────────────────────────────────────────────────────────────────────────────
Makefile                     1       178       41        22      115          4
───────────────────────────────────────────────────────────────────────────────
Makefile                             178       41        22      115          4
───────────────────────────────────────────────────────────────────────────────
Dockerfile                   1        71       16        32       23          0
───────────────────────────────────────────────────────────────────────────────
Dockerfile                            71       16        32       23          0
───────────────────────────────────────────────────────────────────────────────
JSON                         1        11        0         0       11          0
───────────────────────────────────────────────────────────────────────────────
docker/config.json                    11        0         0       11          0
───────────────────────────────────────────────────────────────────────────────
License                      1       202       33         0      169          0
───────────────────────────────────────────────────────────────────────────────
LICENSE                              202       33         0      169          0
───────────────────────────────────────────────────────────────────────────────
Markdown                    17      1185      292         0      893          0
───────────────────────────────────────────────────────────────────────────────
code-of-conduct.md                     3        1         0        2          0
CONTRIBUTING.md                       28        8         0       20          0
README.md                            120       34         0       86          0
docs/image-promotion.md              283       58         0      225          0
docs/github-promotion.md              86       24         0       62          0
docs/file-promotion.md                96       26         0       70          0
~cs/promotion-pull-requests.md       146       42         0      104          0
docs/development.md                  113       28         0       85          0
docs/checks.md                       136       20         0      116          0
~hub/ISSUE_TEMPLATE/feature.md        11        3         0        8          0
~thub/PULL_REQUEST_TEMPLATE.md        57       16         0       41          0
test-e2e/README.md                    51       16         0       35          0
.github/SECURITY.md                   14        5         0        9          0
~/ISSUE_TEMPLATE/bug-report.md        26        9         0       17          0
~ee-structure-nested/README.md         5        0         0        5          0
~d-prefix-is-ignored/README.md         3        0         0        3          0
cmd/cip-mm/README.md                   7        2         0        5          0
───────────────────────────────────────────────────────────────────────────────
Plain Text                   9        91       12         0       79          0
───────────────────────────────────────────────────────────────────────────────
~oilerplate/boilerplate.sh.txt        14        1         0       13          0
~te/boilerplate.generatego.txt        16        4         0       12          0
~late/boilerplate.Makefile.txt        14        1         0       13          0
~te/boilerplate.Dockerfile.txt        14        1         0       13          0
~oilerplate/boilerplate.py.txt        14        1         0       13          0
~oilerplate/boilerplate.go.txt        16        4         0       12          0
~stdata/empty/non-manifest.txt         1        0         0        1          0
~romDir/empty/non-manifest.txt         1        0         0        1          0
~nvalid/empty/non-manifest.txt         1        0         0        1          0
───────────────────────────────────────────────────────────────────────────────
YAML                        82      1030       30       118      882          0
───────────────────────────────────────────────────────────────────────────────
container-structure.yaml               5        0         0        5          0
.golangci.yml                        186        5        46      135          0
dependencies.yaml                     65        8        10       47          0
cloudbuild.yaml                       48        7         5       36          0
~/testdata/files-manifest.yaml         7        0         0        7          0
~estdata/expected/onefile.yaml        11        0         0       11          0
.github/dependabot.yml                11        0         0       11          0
~es/filepromoter-manifest.yaml         4        0         0        4          0
~ts/manyfiles/files/green.yaml         4        1         0        3          0
~ta/expected/manyprojects.yaml        22        0         0       22          0
~le/filepromoter-manifest.yaml         4        0         0        4          0
~manifests/project2/green.yaml         4        1         0        3          0
test-e2e/cip/tests.yaml               79        0         4       75          0
~s/manifests/project2/red.yaml         4        1         0        3          0
~/manifests/project2/blue.yaml         4        1         0        3          0
~/manifests/onefile/files.yaml         7        0         0        7          0
~manifests/project1/green.yaml         4        1         0        3          0
~/manifests/project1/blue.yaml         4        1         0        3          0
~ests/manyfiles/files/red.yaml         4        1         0        3          0
~sanity/promoter-manifest.yaml        21        1         0       20          0
~s/manifests/project1/red.yaml         4        1         0        3          0
~t1/filepromoter-manifest.yaml         4        0         0        4          0
~t2/filepromoter-manifest.yaml         4        0         0        4          0
~sts/manyfiles/files/blue.yaml         4        1         0        3          0
~ts/bar/promoter-manifest.yaml        11        0         0       11          0
~tdata/expected/manyfiles.yaml        11        0         0       11          0
~ts/foo/promoter-manifest.yaml        11        0         0       11          0
~st-e2e/cip-auditor/tests.yaml       126        0        50       76          0
~nifest/images/foo/images.yaml         5        0         1        4          0
~ts/foo/promoter-manifest.yaml         6        0         0        6          0
~ts/bar/promoter-manifest.yaml         6        0         0        6          0
~e-thin/images/bar/images.yaml         4        0         0        4          0
~ts/foo/promoter-manifest.yaml         6        0         0        6          0
~ts/foo/promoter-manifest.yaml         6        0         0        6          0
~e-thin/images/foo/images.yaml         9        0         0        9          0
~prefix/images/foo/images.yaml         5        0         1        4          0
~ests/b/promoter-manifest.yaml        11        0         0       11          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~sic-thin/images/b/images.yaml         3        0         0        3          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ingleton/images/a/images.yaml         3        0         0        3          0
~sic-thin/images/c/images.yaml         3        0         0        3          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~tructure/images/a/images.yaml         3        0         0        3          0
~sic-thin/images/d/images.yaml         3        0         0        3          0
~-rebases/images/b/images.yaml         3        0         0        3          0
~ts/b/c/promoter-manifest.yaml        10        0         0       10          0
~e-nested/images/a/images.yaml         3        0         0        3          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ingleton/images/a/images.yaml         3        0         0        3          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~-rebases/images/a/images.yaml         3        0         0        3          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~e-digest/images/a/images.yaml         3        0         0        3          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~anifests/images/c/images.yaml         3        0         0        3          0
~e-digest/images/b/images.yaml         3        0         0        3          0
~t-digest/images/b/images.yaml         4        0         1        3          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        11        0         0       11          0
~/basic/images/bar/images.yaml         4        0         0        4          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~fest/b/promoter-manifest.yaml        10        0         0       10          0
~gistries/images/b/images.yaml         3        0         0        3          0
~-ignored/images/a/images.yaml         3        0         0        3          0
~/basic/images/foo/images.yaml         9        0         0        9          0
~-rebases/images/a/images.yaml         3        0         0        3          0
~ests/b/promoter-manifest.yaml        10        0         0       10          0
~t-digest/images/a/images.yaml         3        0         0        3          0
~-rebases/images/b/images.yaml         3        0         0        3          0
~ests/d/promoter-manifest.yaml        10        0         0       10          0
~ingleton/images/a/images.yaml         3        0         0        3          0
~gistries/images/a/images.yaml         3        0         0        3          0
~sic-thin/images/a/images.yaml         3        0         0        3          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/a/promoter-manifest.yaml        10        0         0       10          0
~ests/c/promoter-manifest.yaml        11        0         0       11          0
───────────────────────────────────────────────────────────────────────────────
gitignore                    1        17        3         4       10          0
───────────────────────────────────────────────────────────────────────────────
.gitignore                            17        3         4       10          0
───────────────────────────────────────────────────────────────────────────────
Total                      215     24774     2728      3733    18313       1713
───────────────────────────────────────────────────────────────────────────────
Estimated Cost to Develop (organic) $572,127
Estimated Schedule Effort (organic) 11.124009 months
Estimated People Required (organic) 4.569276
───────────────────────────────────────────────────────────────────────────────
Processed 721275 bytes, 0.721 megabytes (SI)
───────────────────────────────────────────────────────────────────────────────
```

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- dockerregistry: Initial refactor to reduce package complexity
```
