### PR TITLE
Implement non-recursive ReadRegistry in GGCR

### DIFF
--- a/internal/legacy/dockerregistry/checks.go
+++ b/internal/legacy/dockerregistry/checks.go
@@ -270,7 +270,7 @@ func MKImageVulnCheck(
 	fakeVulnProducer ImageVulnProducer,
 ) *ImageVulnCheck {
 	return &ImageVulnCheck{
-		*syncContext,
+		syncContext,
 		newPullEdges,
 		severityThreshold,
 		fakeVulnProducer,

--- a/internal/legacy/dockerregistry/inventory_test.go
+++ b/internal/legacy/dockerregistry/inventory_test.go
@@ -2561,9 +2561,10 @@ func TestPromotion(t *testing.T) {
 		edges, err := reg.ToPromotionEdges([]schema.Manifest{test.inputM})
 		require.Nil(t, err)
 
-		filteredEdges, gotClean := test.inputSc.FilterPromotionEdges(
+		filteredEdges, gotClean, err := test.inputSc.FilterPromotionEdges(
 			edges,
 			false)
+		require.NoError(t, err)
 		require.Equal(t, test.expectedFilteredClean, gotClean)
 
 		err = test.inputSc.Promote(

--- a/internal/legacy/dockerregistry/inventory_test.go
+++ b/internal/legacy/dockerregistry/inventory_test.go
@@ -2542,38 +2542,38 @@ func TestPromotion(t *testing.T) {
 		return nil
 	}
 
-	for _, test := range tests {
+	for i := range tests {
 		// Reset captured for each test.
 		captured = make(reg.CapturedRequests)
 		srcReg, err := registry.GetSrcRegistry(registries)
 
 		require.Nil(t, err)
 
-		test.inputSc.SrcRegistry = srcReg
+		tests[i].inputSc.SrcRegistry = srcReg
 
 		// Simulate bad network conditions.
-		if test.badReads != nil {
-			for _, badRead := range test.badReads {
-				test.inputSc.IgnoreFromPromotion(badRead)
+		if tests[i].badReads != nil {
+			for _, badRead := range tests[i].badReads {
+				tests[i].inputSc.IgnoreFromPromotion(badRead)
 			}
 		}
 
-		edges, err := reg.ToPromotionEdges([]schema.Manifest{test.inputM})
+		edges, err := reg.ToPromotionEdges([]schema.Manifest{tests[i].inputM})
 		require.Nil(t, err)
 
-		filteredEdges, gotClean, err := test.inputSc.FilterPromotionEdges(
-			edges,
-			false)
+		filteredEdges, gotClean, err := tests[i].inputSc.FilterPromotionEdges(
+			edges, false,
+		)
 		require.NoError(t, err)
-		require.Equal(t, test.expectedFilteredClean, gotClean)
+		require.Equal(t, tests[i].expectedFilteredClean, gotClean)
 
-		err = test.inputSc.Promote(
+		err = tests[i].inputSc.Promote(
 			filteredEdges,
 			nopStream,
 			&processRequestFake,
 		)
 		require.Nil(t, err)
-		require.Equal(t, test.expectedReqs, captured)
+		require.Equal(t, tests[i].expectedReqs, captured)
 	}
 }
 
@@ -2814,11 +2814,11 @@ func TestValidateEdges(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		edges, err := reg.ToPromotionEdges([]schema.Manifest{test.inputM})
+	for i := range tests {
+		edges, err := reg.ToPromotionEdges([]schema.Manifest{tests[i].inputM})
 		require.Nil(t, err)
-		got := test.inputSc.ValidateEdges(edges)
-		require.Equal(t, test.expected, got)
+		got := tests[i].inputSc.ValidateEdges(edges)
+		require.Equal(t, tests[i].expected, got)
 	}
 }
 
@@ -2973,7 +2973,7 @@ func TestGarbageCollection(t *testing.T) {
 		}
 	}
 
-	for _, test := range tests {
+	for i := range tests {
 		// Reset captured for each test.
 		captured = make(reg.CapturedRequests)
 		nopStream := func(
@@ -2985,10 +2985,10 @@ func TestGarbageCollection(t *testing.T) {
 		srcReg, err := registry.GetSrcRegistry(registries)
 		require.Nil(t, err)
 
-		test.inputSc.SrcRegistry = srcReg
-		test.inputSc.GarbageCollect(test.inputM, nopStream, &processRequestFake)
+		tests[i].inputSc.SrcRegistry = srcReg
+		tests[i].inputSc.GarbageCollect(tests[i].inputM, nopStream, &processRequestFake)
 
-		require.Equal(t, test.expectedReqs, captured)
+		require.Equal(t, tests[i].expectedReqs, captured)
 	}
 }
 
@@ -3132,7 +3132,7 @@ func TestGarbageCollectionMulti(t *testing.T) {
 		}
 	}
 
-	for _, test := range tests {
+	for i := range tests {
 		// Reset captured for each test.
 		captured = make(reg.CapturedRequests)
 		nopStream := func(
@@ -3146,10 +3146,10 @@ func TestGarbageCollectionMulti(t *testing.T) {
 		srcReg, err := registry.GetSrcRegistry(registries)
 		require.Nil(t, err)
 
-		test.inputSc.SrcRegistry = srcReg
-		test.inputSc.GarbageCollect(test.inputM, nopStream, &processRequestFake)
+		tests[i].inputSc.SrcRegistry = srcReg
+		tests[i].inputSc.GarbageCollect(tests[i].inputM, nopStream, &processRequestFake)
 
-		require.Equal(t, test.expectedReqs, captured)
+		require.Equal(t, tests[i].expectedReqs, captured)
 	}
 }
 

--- a/internal/legacy/dockerregistry/types.go
+++ b/internal/legacy/dockerregistry/types.go
@@ -79,6 +79,7 @@ type CollectedLogs struct {
 
 // SyncContext is the main data structure for performing the promotion.
 type SyncContext struct {
+	sync.Mutex
 	Threads           int
 	Confirm           bool
 	UseServiceAccount bool
@@ -105,7 +106,7 @@ type PreCheck interface {
 // ImageVulnCheck implements the PreCheck interface and checks against
 // images that have known vulnerabilities.
 type ImageVulnCheck struct {
-	SyncContext       SyncContext
+	SyncContext       *SyncContext
 	PullEdges         map[PromotionEdge]interface{}
 	SeverityThreshold int
 	FakeVulnProducer  ImageVulnProducer

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -62,7 +62,7 @@ func (di DefaultPromoterImplementation) MakeSyncContext(
 	if err != nil {
 		return nil, errors.Wrap(err, "creating sync context")
 	}
-	return &sc, err
+	return sc, err
 }
 
 // GetPromotionEdges checks the manifests and determines from
@@ -80,7 +80,10 @@ func (di *DefaultPromoterImplementation) GetPromotionEdges(
 	}
 
 	// Run the promotion edge filtering
-	promotionEdges, ok := sc.FilterPromotionEdges(promotionEdges, true)
+	promotionEdges, ok, err := sc.FilterPromotionEdges(promotionEdges, true)
+	if err != nil {
+		return nil, errors.Wrap(err, "filtering promotion edges")
+	}
 	if !ok {
 		// If any funny business was detected during a comparison of the manifests
 		// with the state of the registries, then exit immediately.

--- a/test-e2e/cip-auditor/cip-auditor-e2e.go
+++ b/test-e2e/cip-auditor/cip-auditor-e2e.go
@@ -349,7 +349,7 @@ func (t *E2ETest) clearRepositories() error {
 	// Clear ALL registries in the test manifest. Blank slate!
 	for _, rc := range t.Registries {
 		fmt.Println("CLEARING REPO", rc.Name)
-		clearRepository(rc.Name, &sc)
+		clearRepository(rc.Name, sc)
 	}
 	return nil
 }

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -277,7 +277,7 @@ func (t *E2ETest) clearRepositories() error {
 	// Clear ALL registries in the test manifest. Blank slate!
 	for _, rc := range t.Registries {
 		fmt.Println("CLEARING REPO", rc.Name)
-		clearRepository(rc.Name, &sc)
+		clearRepository(rc.Name, sc)
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

This PR implements the missing part of the registry reading logic in `google/go-containerregistry`. In order to support future parallelism, the SyncContext type now embeds a mutex to allow locking it when writing the images as they are found. Tests are now modified to avoid copying the mutex lock when cycling test cases.

This PR also switches the registry reads to the new ggcr implementation.

#### Which issue(s) this PR fixes:

Follow up to https://github.com/kubernetes-sigs/promo-tools/pull/505 which implemented the recursive part.

None

#### Special notes for your reviewer:

/assign @justaugustus 
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
- Non-recursive registry reads are now reimplemented in `go-containerregistry`.
- Registry reads during image promotion are now performed using the new GGCR implementation
```
