### PR TITLE
Fix build date format for `version` subcommands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: test
 
 GIT_VERSION=$(shell git describe --tags --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
-DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
+DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
 ifdef SOURCE_DATE_EPOCH
     BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Before applying this patch we single quoted the build date like this:

```
> ./bin/kpromo version | grep BuildDate
BuildDate:     '2022-03-22T06:11:44Z'
```

This is now fixed by not quoiting the date in the `Makefile`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed quoted build date in `version` subcommands.
```
