### PR TITLE
test-e2e: Use *.gcr.io/k8s-cip-test-prod/e2e as the test prod endpoints

### DIFF
--- a/test-e2e/cip/fixture/recursive-thin/manifests/bar/promoter-manifest.yaml
+++ b/test-e2e/cip/fixture/recursive-thin/manifests/bar/promoter-manifest.yaml
@@ -2,10 +2,10 @@ registries:
 - name: gcr.io/k8s-staging-cip-test/golden-bar
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
   src: true
-- name: us.gcr.io/k8s-cip-test-prod/golden-bar
+- name: us.gcr.io/k8s-cip-test-prod/e2e/golden-bar
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-cip-test-prod/golden-bar
+- name: eu.gcr.io/k8s-cip-test-prod/e2e/golden-bar
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-cip-test-prod/golden-bar
+- name: asia.gcr.io/k8s-cip-test-prod/e2e/golden-bar
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
 imagesPath: "../../images/bar/images.yaml"

--- a/test-e2e/cip/fixture/recursive-thin/manifests/foo/promoter-manifest.yaml
+++ b/test-e2e/cip/fixture/recursive-thin/manifests/foo/promoter-manifest.yaml
@@ -2,10 +2,10 @@ registries:
 - name: gcr.io/k8s-staging-cip-test/golden-foo
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
   src: true
-- name: us.gcr.io/k8s-cip-test-prod/golden-foo
+- name: us.gcr.io/k8s-cip-test-prod/e2e/golden-foo
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-cip-test-prod/golden-foo
+- name: eu.gcr.io/k8s-cip-test-prod/e2e/golden-foo
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-cip-test-prod/golden-foo
+- name: asia.gcr.io/k8s-cip-test-prod/e2e/golden-foo
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
 imagesPath: "../../images/foo/images.yaml"

--- a/test-e2e/cip/fixture/sanity/promoter-manifest.yaml
+++ b/test-e2e/cip/fixture/sanity/promoter-manifest.yaml
@@ -2,11 +2,11 @@ registries:
 - name: gcr.io/k8s-staging-cip-test/golden-foo
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
   src: true
-- name: us.gcr.io/k8s-cip-test-prod/some/subdir
+- name: us.gcr.io/k8s-cip-test-prod/e2e/some/subdir
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-cip-test-prod/some/subdir
+- name: eu.gcr.io/k8s-cip-test-prod/e2e/some/subdir
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-cip-test-prod/some/subdir
+- name: asia.gcr.io/k8s-cip-test-prod/e2e/some/subdir
   service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com
 
 images:

--- a/test-e2e/cip/tests.yaml
+++ b/test-e2e/cip/tests.yaml
@@ -15,7 +15,7 @@
   invocation:
   - "--manifest=$PWD/test-e2e/cip/fixture/sanity/promoter-manifest.yaml"
   snapshots:
-  - name: us.gcr.io/k8s-cip-test-prod/some/subdir
+  - name: us.gcr.io/k8s-cip-test-prod/e2e/some/subdir
     before: []
     after: &golden-images
     - name: foo
@@ -27,10 +27,10 @@
         sha256:d66f4b0bab4061ef6244f93bea2d414923e7504d92c77a91998c23f909033b02:
         - 1.0-linux_s390x
         sha256:27ba895d293e5e3192b2bb57f0126f923b48d20221bb017e899ca3f5af74f738: []
-  - name: eu.gcr.io/k8s-cip-test-prod/some/subdir
+  - name: eu.gcr.io/k8s-cip-test-prod/e2e/some/subdir
     before: []
     after: *golden-images
-  - name: asia.gcr.io/k8s-cip-test-prod/some/subdir
+  - name: asia.gcr.io/k8s-cip-test-prod/e2e/some/subdir
     before: []
     after: *golden-images
 - name: "recursive-thin"
@@ -46,20 +46,20 @@
   invocation:
   - "--thin-manifest-dir=$PWD/test-e2e/cip/fixture/recursive-thin"
   snapshots:
-  - name: us.gcr.io/k8s-cip-test-prod/golden-bar
+  - name: us.gcr.io/k8s-cip-test-prod/e2e/golden-bar
     before: []
     after: &golden-images-recursive-bar
     - name: bar
       dmap:
         sha256:dd19dc426fa901c12e9a2eeeef8d9ad6c24f50840b8121ccffbba40b5500cb5b:
         - 1.0
-  - name: eu.gcr.io/k8s-cip-test-prod/golden-bar
+  - name: eu.gcr.io/k8s-cip-test-prod/e2e/golden-bar
     before: []
     after: *golden-images-recursive-bar
-  - name: asia.gcr.io/k8s-cip-test-prod/golden-bar
+  - name: asia.gcr.io/k8s-cip-test-prod/e2e/golden-bar
     before: []
     after: *golden-images-recursive-bar
-  - name: us.gcr.io/k8s-cip-test-prod/golden-foo
+  - name: us.gcr.io/k8s-cip-test-prod/e2e/golden-foo
     before: []
     after: &golden-images-recursive-foo
     - name: foo
@@ -71,9 +71,9 @@
         sha256:d66f4b0bab4061ef6244f93bea2d414923e7504d92c77a91998c23f909033b02:
         - 1.0-linux_s390x
         sha256:27ba895d293e5e3192b2bb57f0126f923b48d20221bb017e899ca3f5af74f738: []
-  - name: eu.gcr.io/k8s-cip-test-prod/golden-foo
+  - name: eu.gcr.io/k8s-cip-test-prod/e2e/golden-foo
     before: []
     after: *golden-images-recursive-foo
-  - name: asia.gcr.io/k8s-cip-test-prod/golden-foo
+  - name: asia.gcr.io/k8s-cip-test-prod/e2e/golden-foo
     before: []
     after: *golden-images-recursive-foo


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

test-e2e: Use *.gcr.io/k8s-cip-test-prod/e2e as the test prod endpoints
...which should allow us to re-use k8s-cip-test-prod to canary
test image promotions.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cpanato @puerco @saschagrunert 
cc: @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
