### PR TITLE
kpromo pr: Support for non-SemVer image tags

### DIFF
--- a/cmd/kpromo/cmd/pr/pr.go
+++ b/cmd/kpromo/cmd/pr/pr.go
@@ -83,13 +83,6 @@ func (o *promoteOptions) Validate() error {
 		return errors.Wrap(err, "checking user's fork")
 	}
 
-	// Verify we got a valid tag
-	for _, tag := range o.tags {
-		if _, err := util.TagStringToSemver(tag); err != nil {
-			return errors.Wrapf(err, "verifying tag: %s", tag)
-		}
-	}
-
 	// Check that the GitHub token is set
 	token, isSet := os.LookupEnv(github.TokenEnvKey)
 	if !isSet || token == "" {
@@ -394,4 +387,3 @@ func generatePRBody(opts *promoteOptions) string {
 // - TODO(cip-mm): Fix spacing in tag list
 //                 ref: https://github.com/kubernetes/k8s.io/pull/3212/files#r771604521
 // - TODO(cip-mm): Confirm options are validated
-// - TODO(cip-mm): Support non-SemVer image tags


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR removes the restriction for image tags to adhere to SemVer. Taking debian-base in in k8s-staging-build-image, we cannot match any of the tags, at present:

<img width="764" alt="image" src="https://user-images.githubusercontent.com/60049139/161370880-f1722829-60c6-4030-9a40-abe344b2f319.png">

Since the filter requires an explicit match, I don't think a SemvVer validation buys us anything. With this change, we can make promotion PRs for arbitrary tags (like latest, etc.) assuming they exist.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/promo-tools/issues/520

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kpromo pr: Support non-SemVer image tags
```