### PR TITLE
Add `latest-canary` image tag and manifests for canary promotion jobs

### DIFF
--- a/canary/images/k8s-staging-bom/images.yaml
+++ b/canary/images/k8s-staging-bom/images.yaml
@@ -1,0 +1,4 @@
+- name: bom
+  dmap:
+    "sha256:631ff0f765b4b1ff0b3c81d73698f557f2291aebc822eedf4d265a9ec611af42": ["v0.3.0-rc1"]
+

--- a/canary/images/k8s-staging-bom/images.yaml
+++ b/canary/images/k8s-staging-bom/images.yaml
@@ -1,4 +1,3 @@
 - name: bom
   dmap:
     "sha256:631ff0f765b4b1ff0b3c81d73698f557f2291aebc822eedf4d265a9ec611af42": ["v0.3.0-rc1"]
-

--- a/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -1,0 +1,7 @@
+# Image promotion to canary test repository
+registries:
+- name: gcr.io/k8s-staging-bom
+  src: true
+- name: gcr.io/ulabs-cloud-tests/bom-canary
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+

--- a/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -1,7 +1,5 @@
-# Image promotion to canary test repository
 registries:
 - name: gcr.io/k8s-staging-bom
   src: true
-- name: gcr.io/ulabs-cloud-tests/bom-canary
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-
+- name: us.gcr.io/k8s-cip-test-prod/canary/bom
+  service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,6 +43,8 @@ images:
 - 'gcr.io/$PROJECT_ID/kpromo:$_GIT_TAG'
 - 'gcr.io/$PROJECT_ID/kpromo:$_IMG_VERSION'
 - 'gcr.io/$PROJECT_ID/kpromo:latest'
+- 'gcr.io/$PROJECT_ID/kpromo:latest-canary'
 - 'gcr.io/$PROJECT_ID/kpromo-auditor:$_GIT_TAG'
 - 'gcr.io/$PROJECT_ID/kpromo-auditor:$_IMG_VERSION'
 - 'gcr.io/$PROJECT_ID/kpromo-auditor:latest'
+- 'gcr.io/$PROJECT_ID/kpromo-auditor:latest-canary'

--- a/hack/cip-image.sh
+++ b/hack/cip-image.sh
@@ -135,17 +135,20 @@ main() {
         # Only build and push the auditor image.
         handleVariant "auditor" \
             "${test_tag_prefix}-auditor-test:latest" \
+            "${test_tag_prefix}-auditor-test:latest-canary" \
             "${test_tag_prefix}-auditor-test:${IMG_TAG}" \
             "${test_tag_prefix}-auditor-test:${IMG_VERSION}"
     else
         # Build and push auditor and cip images.
         handleVariant "auditor" \
             "${tag_prefix}-auditor:latest" \
+            "${tag_prefix}-auditor:latest-canary" \
             "${tag_prefix}-auditor:${IMG_TAG}" \
             "${tag_prefix}-auditor:${IMG_VERSION}"
 
         handleVariant "cip" \
             "${tag_prefix}:latest" \
+            "${tag_prefix}:latest-canary" \
             "${tag_prefix}:${IMG_TAG}" \
             "${tag_prefix}:${IMG_VERSION}"
     fi


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- canary: Add canary manifests from `sigs.k8s.io/bom`
- canary: Use `us.gcr.io/k8s-cip-test-prod/canary/bom` as destination
- Add `latest-canary` image tag for canary promotion jobs

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cpanato @puerco 
cc: @kubernetes/release-engineering 
ref: https://github.com/kubernetes/test-infra/pull/25857, https://github.com/kubernetes/k8s.io/pull/3588, https://github.com/kubernetes-sigs/promo-tools/issues/523

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
