### PR TITLE
Move canary builds to run with main svc account

### DIFF
--- a/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -2,4 +2,3 @@ registries:
 - name: gcr.io/k8s-staging-bom
   src: true
 - name: us.gcr.io/k8s-cip-test-prod/canary/bom
-  service-account: k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This moves the canary builds to run with the main promoter account. This enables it to access the signer identity.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

Work to unlock  `pull-test-infra-verify-lint`

#### Special notes for your reviewer:

/assign @cpanato @justaugustus 

#### Does this PR introduce a user-facing change?

```release-note
NONE

```
