### PR TITLE
Update signer account address

### DIFF
--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -107,7 +107,7 @@ var DefaultOptions = &Options{
 	Threads:           10,
 	SeverityThreshold: -1,
 	SignImages:        true,
-	SignerAccount:     "krel-trust@k8s-artifacts-prod.iam.gserviceaccount.com",
+	SignerAccount:     "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
 }
 
 func (o *Options) Validate() error {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update the signer account to the final one that got the permissions merged.
The current default is pointing to an older proposed address.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

Work towards unlocking `ci-promo-tools-image-promo-canary`

#### Special notes for your reviewer:

/assign @justaugustus @cpanato 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
