### PR TITLE
Add second registry to test sig copies

### DIFF
--- a/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/canary/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -2,3 +2,5 @@ registries:
 - name: gcr.io/k8s-staging-bom
   src: true
 - name: us.gcr.io/k8s-cip-test-prod/canary/bom
+- name: us.gcr.io/k8s-cip-test-prod/canary/bom-mirror
+


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a second registry to the bom canary manifests to
test signature copies in the promotion jobs.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

Related to
https://github.com/kubernetes-sigs/promo-tools/issues/523
https://github.com/kubernetes/release/issues/2383


#### Special notes for your reviewer:

/assign @justaugustus 

#### Does this PR introduce a user-facing change?
```release-note
The bom canary now promotes to two registries to test copying the signatures
```
