### PR TITLE
Add sigstore test image to canary promotion

### DIFF
--- a/canary/images/sigstore/images.yaml
+++ b/canary/images/sigstore/images.yaml
@@ -1,0 +1,3 @@
+- name: cosigned
+  dmap:
+    "sha256:45d88f483c2eeaab4a4437cb0990705f285625d9968c3d6a0419a0b88e5668d3": ["v1.7.1"]

--- a/canary/manifests/sigstore/promoter-manifest.yaml
+++ b/canary/manifests/sigstore/promoter-manifest.yaml
@@ -1,0 +1,6 @@
+registries:
+- name: gcr.io/projectsigstore
+  src: true
+- name: us.gcr.io/k8s-cip-test-prod/canary/sigstore
+- name: us.gcr.io/k8s-cip-test-prod/canary/sigstore-mirror
+


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

This PR adds the cosigned multi-arch image to the promotion canary runs. This allows us to pull an image from the sigstore registry and verify we are propagating third-party signatures to the promotion destination.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/assign @justaugustus 

#### Does this PR introduce a user-facing change?


```release-note
Added one of sigstore's cosigned images to the canary runs to check 3rd party signatures
```
