### PR TITLE
Preserve original signatures from promoted images

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -228,6 +228,7 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 	sourceRefStr := fmt.Sprintf(
 		"%s/%s:%s", src.DstRegistry.Name, src.DstImageTag.Name, sigTag,
 	)
+	logrus.WithField("src", sourceRefStr).Infof("Replicating signature to %d images", len(dsts))
 	srcRef, err := name.ParseReference(sourceRefStr)
 	if err != nil {
 		return fmt.Errorf("parsing reference %q: %w", sourceRefStr, err)
@@ -253,6 +254,7 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 
 	// Copy the signatures to the missing registries
 	for _, dstRef := range dstRefs {
+		logrus.WithField("src", srcRef.String()).Infof("replication > %s", dstRef.reference.String())
 		if err := crane.Copy(srcRef.String(), dstRef.reference.String()); err != nil {
 			return fmt.Errorf(
 				"copying signature %s to %s: %w",

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -176,7 +176,7 @@ func (di *DefaultPromoterImplementation) SignImages(
 			)
 			continue
 		}
-		if err := di.copySignatures(
+		if err := di.replicateSignatures(
 			&sortedEdges[digest][0], sortedEdges[digest][1:],
 		); err != nil {
 			return fmt.Errorf("copying signatures: %w", err)
@@ -191,9 +191,9 @@ func digestToSignatureTag(dg image.Digest) string {
 	return strings.ReplaceAll(string(dg), "sha256:", "sha256-") + signatureTagSuffix
 }
 
-// copySignatures takes a source edge (an image) and a list of destinations
+// replicateSignatures takes a source edge (an image) and a list of destinations
 // and copies the signature to all of them
-func (di *DefaultPromoterImplementation) copySignatures(
+func (di *DefaultPromoterImplementation) replicateSignatures(
 	src *reg.PromotionEdge, dsts []reg.PromotionEdge,
 ) error {
 	sigTag := digestToSignatureTag(src.Digest)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This commit implements the `CopySignatures()` function which takes care of copying signatures from the original images to the newly promoted destinations.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2383

#### Special notes for your reviewer:

The previous `copySignatures()` internal function has been renamed to `replicateSignatures()` to avoid confusion

/assign @justaugustus @cpanato @saschagrunert 

#### Does this PR introduce a user-facing change?
```release-note
The image promoter will now carry existing image signatures to the destination registries and append the new signatures to them when signing with the promoter idenity
```
