### PR TITLE
Add integration test for imagepromoter.PromoteImages()

### DIFF
--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -47,6 +47,10 @@ func New() *Promoter {
 	}
 }
 
+func (p *Promoter) SetImplementation(pi promoterImplementation) {
+	p.impl = pi
+}
+
 //counterfeiter:generate . promoterImplementation
 
 // promoterImplementation handles all the functionality in the promoter

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagepromoter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
+	imagepromoter "sigs.k8s.io/promo-tools/v3/promoter/image"
+	imagefakes "sigs.k8s.io/promo-tools/v3/promoter/image/imagefakes"
+	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
+)
+
+func TestPromoteImages(t *testing.T) {
+	sut := imagepromoter.Promoter{}
+	testErr := errors.New("synthetic error")
+	for _, tc := range []struct {
+		shouldErr bool
+		msg       string
+		prepare   func(*imagefakes.FakePromoterImplementation)
+	}{
+		{
+			// No errors
+			shouldErr: false,
+			msg:       "No errors",
+			prepare:   func(fpi *imagefakes.FakePromoterImplementation) {},
+		},
+		{
+			// ValidateOptions fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.ValidateOptionsReturns(testErr)
+			},
+		},
+		{
+			// ActivateServiceAccountsrseManifests fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.ActivateServiceAccountsReturns(testErr)
+			},
+		},
+		{
+			// PrewarmTUFCache fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.PrewarmTUFCacheReturns(testErr)
+			},
+		},
+		{
+			// ParseManifests fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.ParseManifestsReturns(nil, testErr)
+			},
+		},
+		{
+			// MakeSyncContext fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.MakeSyncContextReturns(nil, testErr)
+			},
+		},
+		{
+			// GetPromotionEdges fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.GetPromotionEdgesReturns(nil, testErr)
+			},
+		},
+		{
+			// ValidateStagingSignatures fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
+				fpi.ValidateStagingSignaturesReturns(nil, testErr)
+			},
+		},
+		{
+			// PromoteImages fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
+				fpi.PromoteImagesReturns(testErr)
+			},
+		},
+		{
+			// CopySignatures fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
+				fpi.CopySignaturesReturns(testErr)
+			},
+		},
+		{
+			// SignImages fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
+				fpi.SignImagesReturns(testErr)
+			},
+		},
+		{
+			// WriteSBOMs fails
+			shouldErr: true,
+			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
+				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
+				fpi.WriteSBOMsReturns(testErr)
+			},
+		},
+	} {
+		mock := imagefakes.FakePromoterImplementation{}
+		tc.prepare(&mock)
+		sut.SetImplementation(&mock)
+		if tc.shouldErr {
+			require.Error(t, sut.PromoteImages(&options.Options{Confirm: true}), tc.msg)
+		}
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Add integrations tests to `imagepromoter.PromoteImages()`.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @Verolop @ameukam @cpanato 

#### Does this PR introduce a user-facing change?
```release-note
Added integration tests to `imagepromoter.PromoteImages()`.
```
