### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/cmd/kpromo/cmd/cip/audit.go
+++ b/cmd/kpromo/cmd/cip/audit.go
@@ -17,7 +17,8 @@ limitations under the License.
 package cip
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/cli"
@@ -35,10 +36,10 @@ Start an audit server that responds to Pub/Sub push events.
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.Wrap(
-			cli.RunAuditCmd(auditOpts),
-			"run `cip audit`",
-		)
+		if err := cli.RunAuditCmd(auditOpts); err != nil {
+			return fmt.Errorf("run `cip audit`: %w", err)
+		}
+		return nil
 	},
 }
 

--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -19,7 +19,6 @@ package cip
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/cli"
@@ -39,10 +38,10 @@ Promote images from a staging registry to production
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.Wrap(
-			cli.RunPromoteCmd(runOpts),
-			"run `cip run`",
-		)
+		if err := cli.RunPromoteCmd(runOpts); err != nil {
+			return fmt.Errorf("run `cip run`: %w", err)
+		}
+		return nil
 	},
 }
 

--- a/cmd/kpromo/cmd/manifest/files.go
+++ b/cmd/kpromo/cmd/manifest/files.go
@@ -18,10 +18,10 @@ package manifest
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/promo-tools/v3/promobot"
@@ -35,7 +35,10 @@ var filesCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.Wrap(runFileManifest(filesOpts), "run `kpromo manifest files`")
+		if err := runFileManifest(filesOpts); err != nil {
+			return fmt.Errorf("run `kpromo manifest files`: %w", err)
+		}
+		return nil
 	},
 }
 
@@ -71,7 +74,7 @@ func runFileManifest(opts *promobot.GenerateManifestOptions) error {
 
 	src, err := filepath.Abs(opts.BaseDir)
 	if err != nil {
-		return errors.Wrapf(err, "resolving %q to absolute path", src)
+		return fmt.Errorf("resolving %q to absolute path: %w", src, err)
 	}
 
 	opts.BaseDir = src
@@ -83,7 +86,7 @@ func runFileManifest(opts *promobot.GenerateManifestOptions) error {
 
 	manifestYAML, err := yaml.Marshal(manifest)
 	if err != nil {
-		return errors.Wrap(err, "serializing manifest")
+		return fmt.Errorf("serializing manifest: %w", err)
 	}
 
 	if _, err := os.Stdout.Write(manifestYAML); err != nil {

--- a/cmd/kpromo/cmd/run/files.go
+++ b/cmd/kpromo/cmd/run/files.go
@@ -18,8 +18,8 @@ package run
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/promo-tools/v3/promobot"
@@ -32,7 +32,10 @@ var filesCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.Wrap(runFilePromotion(filesOpts), "run `kpromo run files`")
+		if err := runFilePromotion(filesOpts); err != nil {
+			return fmt.Errorf("run `kpromo run files`: %w", err)
+		}
+		return nil
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.5.0

--- a/image/image.go
+++ b/image/image.go
@@ -17,11 +17,11 @@ limitations under the License.
 package image
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
 	"sigs.k8s.io/release-utils/util"
@@ -56,12 +56,12 @@ func NewManifestListFromFile(manifestPath string) (imagesList *ManifestList, err
 	}
 	yamlCode, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading yaml code from file")
+		return nil, fmt.Errorf("reading yaml code from file: %w", err)
 	}
 
 	imagesList = &ManifestList{}
 	if err := imagesList.Parse(yamlCode); err != nil {
-		return nil, errors.Wrap(err, "parsing manifest yaml")
+		return nil, fmt.Errorf("parsing manifest yaml: %w", err)
 	}
 
 	return imagesList, nil
@@ -79,11 +79,11 @@ func (imagesList *ManifestList) Parse(yamlCode []byte) error {
 func (imagesList *ManifestList) Write(filePath string) error {
 	yamlCode, err := imagesList.ToYAML()
 	if err != nil {
-		return errors.Wrap(err, "while marshalling image list")
+		return fmt.Errorf("while marshalling image list: %w", err)
 	}
 	// Write the yaml into the specified file
 	if err := os.WriteFile(filePath, yamlCode, os.FileMode(0o644)); err != nil {
-		return errors.Wrap(err, "writing yaml code into file")
+		return fmt.Errorf("writing yaml code into file: %w", err)
 	}
 
 	return nil

--- a/internal/legacy/cli/audit.go
+++ b/internal/legacy/cli/audit.go
@@ -17,10 +17,10 @@ limitations under the License.
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	guuid "github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/audit"
@@ -41,7 +41,7 @@ func RunAuditCmd(opts *AuditOptions) error {
 	opts.set()
 
 	if err := validateAuditOptions(opts); err != nil {
-		return errors.Wrap(err, "validating audit options")
+		return fmt.Errorf("validating audit options: %w", err)
 	}
 
 	auditorContext, err := audit.InitRealServerContext(
@@ -52,7 +52,7 @@ func RunAuditCmd(opts *AuditOptions) error {
 		opts.UUID,
 	)
 	if err != nil {
-		return errors.Wrap(err, "creating auditor context")
+		return fmt.Errorf("creating auditor context: %w", err)
 	}
 
 	if opts.Verbose {

--- a/internal/promoter/image/securityscan.go
+++ b/internal/promoter/image/securityscan.go
@@ -17,7 +17,7 @@ limitations under the License.
 package imagepromoter
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	reg "sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry"
 	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
@@ -39,7 +39,7 @@ func (di *DefaultPromoterImplementation) ScanEdges(
 			),
 		},
 	); err != nil {
-		return errors.Wrap(err, "checking image vulnerabilities")
+		return fmt.Errorf("checking image vulnerabilities: %w", err)
 	}
 	di.PrintSection("END (VULNSCAN)", opts.Confirm)
 	return nil

--- a/test-e2e/cip/e2e.go
+++ b/test-e2e/cip/e2e.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -26,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
@@ -146,7 +146,7 @@ func checkSnapshot(
 	// Get the snapshot of the repo
 	got, err := getSnapshot(repoRoot, repo, rcs)
 	if err != nil {
-		return errors.Wrapf(err, "getting snapshot of %s", repo)
+		return fmt.Errorf("getting snapshot of %s: %w", repo, err)
 	}
 
 	// After signing images, the repo snapshots will never match. In order
@@ -157,7 +157,7 @@ func checkSnapshot(
 	diff := cmp.Diff(got, expected)
 	if diff != "" {
 		fmt.Printf("the following diff exists: %s", diff)
-		return errors.Errorf("expected equivalent image sets")
+		return errors.New("expected equivalent image sets")
 	}
 
 	return nil
@@ -165,7 +165,7 @@ func checkSnapshot(
 
 func testSetup(repoRoot string, t *E2ETest) error {
 	if err := t.clearRepositories(); err != nil {
-		return errors.Wrap(err, "cleaning test repository")
+		return fmt.Errorf("cleaning test repository: %w", err)
 	}
 
 	goldenPush := fmt.Sprintf("%s/test-e2e/golden-images/push-golden.sh", repoRoot)
@@ -283,7 +283,7 @@ func (t *E2ETest) clearRepositories() error {
 		true,
 		true)
 	if err != nil {
-		return errors.Wrap(err, "trying to create sync context")
+		return fmt.Errorf("trying to create sync context: %w", err)
 	}
 
 	sc.ReadRegistries(


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now use the standard error wrapping instead of github.com/pkg/errors.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
