### PR TITLE
Default --image and --digest to null list

### DIFF
--- a/cmd/kpromo/cmd/pr/pr.go
+++ b/cmd/kpromo/cmd/pr/pr.go
@@ -137,7 +137,7 @@ func init() {
 		"image",
 		"",
 		// TODO: Parameterize
-		[]string{""},
+		[]string{},
 		"image to promote. If not specified, all images matching the tag will be promoted",
 	)
 
@@ -146,7 +146,7 @@ func init() {
 		"digests",
 		"",
 		// TODO: Parameterize
-		[]string{""},
+		[]string{},
 		"digests to promote. If not specified, all images matching the tag will be promoted",
 	)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This commit defaults the `--image` and `--digest` command
line params instead of single, empty string element.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/promo-tools/issues/546

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where `kpromo pr` would not run correctly unless all command line parameters were specified
```
