### PR TITLE
Add an authenticated client to gcrane

### DIFF
--- a/internal/legacy/dockerregistry/inventory.go
+++ b/internal/legacy/dockerregistry/inventory.go
@@ -1750,7 +1750,10 @@ func (sc *SyncContext) Promote(
 						)
 					}
 
-					if err := crane.Copy(srcVertex, dstVertex); err != nil {
+					opts := []crane.Option{
+						crane.WithAuthFromKeychain(gcrane.Keychain),
+					}
+					if err := crane.Copy(srcVertex, dstVertex, opts...); err != nil {
 						logrus.Error(err)
 						errors = append(
 							errors,

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -26,6 +26,7 @@ import (
 
 	credentials "cloud.google.com/go/iam/credentials/apiv1"
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/nozzle/throttler"
 	"github.com/sigstore/sigstore/pkg/tuf"
@@ -186,7 +187,10 @@ func (di *DefaultPromoterImplementation) CopySignatures(
 			}
 
 			logrus.Infof("Signature pre copy: %s to %s", srcRefString, dstRefString)
-			if err := crane.Copy(srcRef.String(), dstRef.String()); err != nil {
+			opts := []crane.Option{
+				crane.WithAuthFromKeychain(gcrane.Keychain),
+			}
+			if err := crane.Copy(srcRef.String(), dstRef.String(), opts...); err != nil {
 				t.Done(fmt.Errorf(
 					"copying signature %s to %s: %w",
 					srcRef.String(), dstRef.String(), err,
@@ -345,7 +349,10 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 	// Copy the signatures to the missing registries
 	for _, dstRef := range dstRefs {
 		logrus.WithField("src", srcRef.String()).Infof("replication > %s", dstRef.reference.String())
-		if err := crane.Copy(srcRef.String(), dstRef.reference.String()); err != nil {
+		opts := []crane.Option{
+			crane.WithAuthFromKeychain(gcrane.Keychain),
+		}
+		if err := crane.Copy(srcRef.String(), dstRef.reference.String(), opts...); err != nil {
 			return fmt.Errorf(
 				"copying signature %s to %s: %w",
 				srcRef.String(), dstRef.reference.String(), err,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

gcrane is copying to target registries without being authenticated and those pushes fail for Artifact Registry.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
crane copy operations in kpromo now use `gcrane.Keychain` to authenticate.  
```

https://kubernetes.slack.com/archives/CJH2GBF7Y/p1660658716152579
