### PR TITLE
use gcrane.Keychain instead of gcloud for auth

### DIFF
--- a/internal/legacy/dockerregistry/inventory.go
+++ b/internal/legacy/dockerregistry/inventory.go
@@ -1750,7 +1750,9 @@ func (sc *SyncContext) Promote(
 						)
 					}
 
-					if err := crane.Copy(srcVertex, dstVertex); err != nil {
+					if err := crane.Copy(srcVertex, dstVertex,
+						crane.WithAuthFromKeychain(gcrane.Keychain),
+					); err != nil {
 						logrus.Error(err)
 						errors = append(
 							errors,

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -348,7 +348,7 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 	// Copy the signatures to the missing registries
 	for _, dstRef := range dstRefs {
 		logrus.WithField("src", srcRef.String()).Infof("replication > %s", dstRef.reference.String())
-		if err := crane.Copy(srcRef.String(), dstRef.String(),
+		if err := crane.Copy(srcRef.String(), dstRef.reference.String(),
 			crane.WithAuthFromKeychain(gcrane.Keychain),
 		); err != nil {
 			return fmt.Errorf(

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -26,6 +26,7 @@ import (
 
 	credentials "cloud.google.com/go/iam/credentials/apiv1"
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/gcrane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/nozzle/throttler"
 	"github.com/sigstore/sigstore/pkg/tuf"
@@ -186,7 +187,9 @@ func (di *DefaultPromoterImplementation) CopySignatures(
 			}
 
 			logrus.Infof("Signature pre copy: %s to %s", srcRefString, dstRefString)
-			if err := crane.Copy(srcRef.String(), dstRef.String()); err != nil {
+			if err := crane.Copy(srcRef.String(), dstRef.String(),
+				crane.WithAuthFromKeychain(gcrane.Keychain),
+			); err != nil {
 				t.Done(fmt.Errorf(
 					"copying signature %s to %s: %w",
 					srcRef.String(), dstRef.String(), err,
@@ -345,7 +348,9 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 	// Copy the signatures to the missing registries
 	for _, dstRef := range dstRefs {
 		logrus.WithField("src", srcRef.String()).Infof("replication > %s", dstRef.reference.String())
-		if err := crane.Copy(srcRef.String(), dstRef.reference.String()); err != nil {
+		if err := crane.Copy(srcRef.String(), dstRef.String(),
+			crane.WithAuthFromKeychain(gcrane.Keychain),
+		); err != nil {
 			return fmt.Errorf(
 				"copying signature %s to %s: %w",
 				srcRef.String(), dstRef.reference.String(), err,


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This uses `gcrane.Keychain` instead of the `pkg/crane`'s default [`authn.DefaultKeychain`](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/authn#DefaultKeychain) to provide auth for requests to GCR.

`authn.DefaultKeychain` reads the Docker config (e.g., `~/.docker/config.json`) to learn how to get auth, and this method is configured to use `gcloud` to provide auth. Invoking `gcloud` like this is slow (see issue).

[`gcrane.Keychain`](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/gcrane#pkg-variables) uses [`google.Keychain`](https://pkg.go.dev/github.com/google/go-containerregistry@v0.11.0/pkg/v1/google#Keychain), which first attempts to find Application Default Credentials from the environment (as `gcloud` does), then as a fallback invokes `gcloud` once to get credentials, and caches those for future requests.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/promo-tools/issues/631

#### Special notes for your reviewer:

I haven't run this code to see if it works or practically what kind of performance improvement you should expect. Let me know if you'd like me to do that, and instructions on how I might test it out at the scale you normally see.

This at least shouldn't have any performance regression beyond what you already see today.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

cc @jonjohnsonjr @puerco