### PR TITLE
Add logrus hook to show all timestamps and their diffs

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -88,6 +88,7 @@ func (di *DefaultPromoterImplementation) FindSingedEdges(
 			seenEdges.list[edge.SrcReference()] = struct{}{}
 			seenEdges.Unlock()
 
+			logrus.Infof("Checking if image is signed: %s", edge.SrcReference())
 			isSigned, err := signer.IsImageSigned(edge.SrcReference())
 			if err != nil {
 				t.Done(
@@ -95,6 +96,7 @@ func (di *DefaultPromoterImplementation) FindSingedEdges(
 				)
 				return
 			}
+			logrus.Infof("Image %s is signed: %v", edge.SrcReference(), isSigned)
 
 			if !isSigned {
 				t.Done(nil)

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -20,7 +20,6 @@ package imagepromoter
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -98,7 +97,7 @@ type promoterImplementation interface {
 // PromoteImages is the main method for image promotion
 // it runs by taking all its parameters from a set of options.
 func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
-	logrus.Infof("kpromo[%d]: PromoteImages start", time.Now().Unix())
+	logrus.Infof("PromoteImages start")
 
 	// Validate the options. Perhaps another image-specific
 	// validation function may be needed.
@@ -116,7 +115,7 @@ func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
 		return fmt.Errorf("prewarming TUF cache: %w", err)
 	}
 
-	logrus.Infof("kpromo[%d]: Parsing manifests", time.Now().Unix())
+	logrus.Infof("Parsing manifests")
 	mfests, err := p.impl.ParseManifests(opts)
 	if err != nil {
 		return fmt.Errorf("parsing manifests: %w", err)
@@ -125,20 +124,20 @@ func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
 	p.impl.PrintVersion()
 	p.impl.PrintSection("START (PROMOTION)", opts.Confirm)
 
-	logrus.Infof("kpromo[%d]: Creating sync context manifests", time.Now().Unix())
+	logrus.Infof("Creating sync context manifests")
 	sc, err := p.impl.MakeSyncContext(opts, mfests)
 	if err != nil {
 		return fmt.Errorf("creating sync context: %w", err)
 	}
 
-	logrus.Infof("kpromo[%d]: Getting promotion edges", time.Now().Unix())
+	logrus.Infof("Getting promotion edges")
 	promotionEdges, err := p.impl.GetPromotionEdges(sc, mfests)
 	if err != nil {
 		return fmt.Errorf("filtering edges: %w", err)
 	}
 
 	// MakeProducer
-	logrus.Infof("kpromo[%d]: Creating producer function", time.Now().Unix())
+	logrus.Infof("Creating producer function")
 	producerFunc := p.impl.MakeProducerFunction(sc.UseServiceAccount)
 
 	// TODO: Let's rethink this option
@@ -148,7 +147,7 @@ func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
 	}
 
 	// Verify any signatures in staged images
-	logrus.Infof("kpromo[%d]: Validating staging signatures", time.Now().Unix())
+	logrus.Infof("Validating staging signatures")
 	signedEdges, err := p.impl.ValidateStagingSignatures(promotionEdges)
 	if err != nil {
 		return fmt.Errorf("checking signtaures in staging images: %w", err)
@@ -159,17 +158,17 @@ func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
 		return p.impl.PrecheckAndExit(opts, mfests)
 	}
 
-	logrus.Infof("kpromo[%d]: Promoting images", time.Now().Unix())
+	logrus.Infof("Promoting images")
 	if err := p.impl.PromoteImages(sc, promotionEdges, producerFunc); err != nil {
 		return fmt.Errorf("running promotion: %w", err)
 	}
 
-	logrus.Infof("kpromo[%d]: Replicating signatures", time.Now().Unix())
+	logrus.Infof("Replicating signatures")
 	if err := p.impl.CopySignatures(opts, sc, signedEdges); err != nil {
 		return fmt.Errorf("copying existing signatures: %w", err)
 	}
 
-	logrus.Infof("kpromo[%d]: Signing images", time.Now().Unix())
+	logrus.Infof("Signing images")
 	if err := p.impl.SignImages(opts, sc, promotionEdges); err != nil {
 		return fmt.Errorf("signing images: %w", err)
 	}
@@ -178,7 +177,7 @@ func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
 		return fmt.Errorf("writing sboms: %w", err)
 	}
 
-	logrus.Infof("kpromo[%d]: Finish", time.Now().Unix())
+	logrus.Infof("Finish")
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
We need to investigate what is taking so much time during the promotion. The hook is a start and we should add more verbose logging once we identify huge diffs without any obvious fix.

Builds on top of https://github.com/kubernetes-sigs/promo-tools/pull/638

The patch adds a logrus hook to the image promoter to display the timestamps including milliseconds as well their diff to the previous log message.

For example this:

```
logrus.Infof("First")
time.Sleep(100 * time.Millisecond)
logrus.Infof("Second")
time.Sleep(420 * time.Millisecond)
logrus.Infof("Third")
```

Will result in:

```
INFO[10:45:25.528] First                                         diff=0s
INFO[10:45:25.628] Second                                        diff=100ms
INFO[10:45:26.048] Third                                         diff=421ms
```



#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/promo-tools/issues/637
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Display log timestamps and their diffs to the previous message during the promotion.
```
