### PR TITLE
Add prow diff option

### DIFF
--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -76,6 +76,13 @@ manifests but instead of defining the 'images: ...' field directly, the
 the 'images: ...' contents`,
 	)
 
+	CipCmd.PersistentFlags().BoolVar(
+		&runOpts.UseProwManifestDiff,
+		"use-prow-manifest-diff",
+		runOpts.UseProwManifestDiff,
+		"use only the latest diff for the manifest dir. Works only on prow.",
+	)
+
 	CipCmd.PersistentFlags().IntVar(
 		&runOpts.Threads,
 		"threads",

--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -194,7 +194,7 @@ func Write(m schema.Manifest, rii registry.RegInvImage) error {
 func Find(o *GrowOptions) (schema.Manifest, error) {
 	var err error
 	var manifests []schema.Manifest
-	manifests, err = schema.ParseThinManifestsFromDir(o.BaseDir)
+	manifests, err = schema.ParseThinManifestsFromDir(o.BaseDir, false)
 	if err != nil {
 		return schema.Manifest{}, err
 	}

--- a/internal/legacy/dockerregistry/checks.go
+++ b/internal/legacy/dockerregistry/checks.go
@@ -118,7 +118,7 @@ func (check *ImageRemovalCheck) Run() error {
 			" repo: %v", err)
 	}
 
-	mfests, err := schema.ParseThinManifestsFromDir(check.GitRepoPath)
+	mfests, err := schema.ParseThinManifestsFromDir(check.GitRepoPath, false)
 	if err != nil {
 		return fmt.Errorf("could not parse manifests from the directory: %v",
 			err)

--- a/internal/legacy/dockerregistry/inventory_test.go
+++ b/internal/legacy/dockerregistry/inventory_test.go
@@ -505,7 +505,7 @@ func TestParseThinManifestsFromDir(t *testing.T) {
 			expectedModified = append(expectedModified, mfest)
 		}
 
-		got, errParse := schema.ParseThinManifestsFromDir(fixtureDir)
+		got, errParse := schema.ParseThinManifestsFromDir(fixtureDir, false)
 
 		// Clear private fields (redundant data) that are calculated on-the-fly
 		// (it's too verbose to include them here; besides, it's not what we're
@@ -551,7 +551,7 @@ func TestValidateThinManifestsFromDir(t *testing.T) {
 	for _, testInput := range shouldBeValid {
 		fixtureDir := filepath.Join(pwd, "valid", testInput)
 
-		mfests, errParse := schema.ParseThinManifestsFromDir(fixtureDir)
+		mfests, errParse := schema.ParseThinManifestsFromDir(fixtureDir, false)
 		require.Nil(t, errParse)
 
 		_, edgeErr := reg.ToPromotionEdges(mfests)
@@ -601,7 +601,7 @@ func TestValidateThinManifestsFromDir(t *testing.T) {
 		// It could be that a manifest, taken individually, failed on its own,
 		// before we even get to ValidateThinManifestsFromDir(). So handle these
 		// cases as well.
-		mfests, errParse := schema.ParseThinManifestsFromDir(fixtureDir)
+		mfests, errParse := schema.ParseThinManifestsFromDir(fixtureDir, false)
 
 		var errParseStr string
 		var expectedParseErrorStr string

--- a/internal/legacy/dockerregistry/schema/manifest_test.go
+++ b/internal/legacy/dockerregistry/schema/manifest_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/release-utils/command"
+)
+
+func TestParseThinManifestsFromDirPostsubmit(t *testing.T) {
+	t.Setenv("JOB_TYPE", "postsubmit")
+
+	tmpDir, err := os.MkdirTemp("", "k8s.io-")
+	require.Nil(t, err)
+	testDir := filepath.Join(tmpDir, "test")
+	defer require.Nil(t, os.RemoveAll(tmpDir))
+
+	const (
+		repo   = "https://github.com/kubernetes/k8s.io"
+		git    = "git"
+		commit = "86b8f390aac2e6c244868143ea03c8326c9064a0"
+	)
+
+	require.Nil(t, command.New(git, "clone", repo, testDir).RunSilentSuccess())
+	require.Nil(t, command.NewWithWorkDir(testDir, git, "checkout", commit).RunSilentSuccess())
+
+	for _, onlyProwDiff := range []bool{true, false} {
+		manifests, err := ParseThinManifestsFromDir(
+			filepath.Join(testDir, "k8s.gcr.io"), onlyProwDiff,
+		)
+
+		require.Nil(t, err)
+		require.Len(t, manifests, 76)
+
+		imageCount := 0
+		for _, manifest := range manifests {
+			imageCount += len(manifest.Images)
+		}
+
+		if onlyProwDiff {
+			assert.Equal(t, imageCount, 31)
+		} else {
+			assert.Equal(t, imageCount, 623)
+		}
+	}
+}

--- a/internal/legacy/remotemanifest/git.go
+++ b/internal/legacy/remotemanifest/git.go
@@ -51,7 +51,7 @@ func (remote *Git) Fetch() ([]schema.Manifest, error) {
 	// There is no remote; use the local path directly.
 	if remote.repoURL.String() == "" {
 		manifests, err := schema.ParseThinManifestsFromDir(
-			remote.thinManifestDirPath)
+			remote.thinManifestDirPath, false)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func (remote *Git) Fetch() ([]schema.Manifest, error) {
 	}
 
 	manifests, err := schema.ParseThinManifestsFromDir(
-		filepath.Join(repoPath, remote.thinManifestDirPath))
+		filepath.Join(repoPath, remote.thinManifestDirPath), false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/promoter/image/imagepromotion.go
+++ b/internal/promoter/image/imagepromotion.go
@@ -44,7 +44,7 @@ func (di *DefaultPromoterImplementation) ParseManifests(opts *options.Options) (
 		mfests = []schema.Manifest{mfest}
 		// The thin manifests
 	} else if opts.ThinManifestDir != "" {
-		mfests, err = schema.ParseThinManifestsFromDir(opts.ThinManifestDir)
+		mfests, err = schema.ParseThinManifestsFromDir(opts.ThinManifestDir, opts.UseProwManifestDiff)
 		if err != nil {
 			return nil, fmt.Errorf("parsing thin manifest directory: %w", err)
 		}

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -33,6 +33,9 @@ type Options struct {
 	// Use a service account when true
 	UseServiceAcct bool
 
+	// Use only the latest diff for the manifests. Works only when running in prow.
+	UseProwManifestDiff bool
+
 	// Manifest is the path of a manifest file
 	Manifest string
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds an option to only use the latest prow diff for the manifest retrieval.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes #654 
Fixes https://github.com/kubernetes/k8s.io/issues/4374
Refers to https://github.com/kubernetes-sigs/promo-tools/issues/637
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `kpromo cip --use-prow-manifest-diff` option. 
```
