### PR TITLE
Take digests into account for prow diff

### DIFF
--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -19,7 +19,7 @@ package manifest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -185,7 +185,7 @@ func Write(m schema.Manifest, rii registry.RegInvImage) error {
 	logrus.Infoln("RENDER", imagesPath)
 
 	// Write the file.
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		imagesPath, []byte(rii.ToYAML(registry.YamlMarshalingOpts{})), 0o644)
 	return err
 }

--- a/internal/legacy/cli/run.go
+++ b/internal/legacy/cli/run.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -87,5 +88,9 @@ func RunPromoteCmd(opts *options.Options) error {
 	}
 
 	// Mode 4: Image promotion
-	return cip.PromoteImages(opts)
+	if err := cip.PromoteImages(opts); err != nil {
+		return fmt.Errorf("promote images: %w", err)
+	}
+
+	return nil
 }

--- a/internal/legacy/dockerregistry/schema/manifest_test.go
+++ b/internal/legacy/dockerregistry/schema/manifest_test.go
@@ -32,7 +32,7 @@ func TestParseThinManifestsFromDirPostsubmit(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "k8s.io-")
 	require.Nil(t, err)
 	testDir := filepath.Join(tmpDir, "test")
-	defer require.Nil(t, os.RemoveAll(tmpDir))
+	defer os.RemoveAll(tmpDir)
 
 	const (
 		repo   = "https://github.com/kubernetes/k8s.io"
@@ -51,15 +51,19 @@ func TestParseThinManifestsFromDirPostsubmit(t *testing.T) {
 		require.Nil(t, err)
 		require.Len(t, manifests, 76)
 
-		imageCount := 0
+		var digestCount, imageCount int
 		for _, manifest := range manifests {
 			imageCount += len(manifest.Images)
+			for _, image := range manifest.Images {
+				digestCount += len(image.Dmap)
+			}
 		}
 
+		expectedDigestCount := 12344
 		if onlyProwDiff {
-			assert.Equal(t, imageCount, 31)
-		} else {
-			assert.Equal(t, imageCount, 623)
+			expectedDigestCount = 1
 		}
+		assert.Equal(t, expectedDigestCount, digestCount)
+		assert.Equal(t, 623, imageCount)
 	}
 }

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -173,8 +173,9 @@ func (p *Promoter) PromoteImages(opts *options.Options) (err error) {
 		return fmt.Errorf("signing images: %w", err)
 	}
 
+	logrus.Infof("Writing SBOMs")
 	if err := p.impl.WriteSBOMs(opts, sc, promotionEdges); err != nil {
-		return fmt.Errorf("writing sboms: %w", err)
+		return fmt.Errorf("writing SBOMs: %w", err)
 	}
 
 	logrus.Infof("Finish")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now also take the possible digests to promote into account rather than the whole image file. This should provide an additional performance boost especially for large manifests.

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes-sigs/promo-tools/issues/637 and https://github.com/kubernetes/k8s.io/issues/4374

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Filter digests if `--use-prow-manifest-diff` is used.
```
