### PR TITLE
Remove unused `kpromo cip --threads` flag

### DIFF
--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -83,13 +83,6 @@ the 'images: ...' contents`,
 		"use only the latest diff for the manifest dir. Works only on prow.",
 	)
 
-	CipCmd.PersistentFlags().IntVar(
-		&runOpts.Threads,
-		"threads",
-		options.DefaultOptions.Threads,
-		"number of concurrent goroutines to use when talking to GCR",
-	)
-
 	CipCmd.PersistentFlags().BoolVar(
 		&runOpts.JSONLogSummary,
 		"json-log-summary",


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The flag is not used anywhere so we can remove it.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Refers to https://github.com/kubernetes/test-infra/pull/27887
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed unused `kpromo cip --threads` flag
```
