### PR TITLE
Dedup images to verify for signed edges

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -56,12 +56,15 @@ const (
 func (di *DefaultPromoterImplementation) ValidateStagingSignatures(
 	edges map[reg.PromotionEdge]interface{},
 ) (map[reg.PromotionEdge]interface{}, error) {
-	refs := []string{}
 	refsToEdges := map[string]reg.PromotionEdge{}
 	for edge := range edges {
 		ref := edge.SrcReference()
-		refs = append(refs, ref)
 		refsToEdges[ref] = edge
+	}
+
+	refs := []string{}
+	for ref := range refsToEdges {
+		refs = append(refs, ref)
 	}
 
 	res, err := di.signer.VerifyImages(refs...)


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We now verify only a deduped list of src references for their signatures instead of multiples from their registry.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/promo-tools/issues/637 and https://github.com/kubernetes/k8s.io/issues/4374
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug to dedup images list before verifying their signatures. 
```
