### PR TITLE
Create a new signer after getting the identity token

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -167,6 +167,8 @@ func (di *DefaultPromoterImplementation) SignImages(
 	}
 	signOpts.IdentityToken = token
 
+	di.signer = sign.New(signOpts)
+
 	// We only sign the first image of each edge. If there are more
 	// than one destination registries for an image, we copy the
 	// signature to avoid varying valid signatures in each registry.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We have found a regression where promoted images are signed with `k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com` instead of with `krel-trust@k8s-releng-prod.iam.gserviceaccount.com`.

I _think_ this is a regression caused by https://github.com/kubernetes-sigs/promo-tools/commit/e8a26d205a9b44ddfa550c6e34eaa3fc3b57c278

Before this commit, we were creating a new Signer for each image we were signing. This turned out to be causing performance issues, so we stopped doing this and started reusing a single Signer object. This Signer object is created here: https://github.com/kubernetes-sigs/promo-tools/blob/d8a1c646670799b0437aca6c56886a8483587197/internal/promoter/image/impl.go#L57

However, the identity token is attached to the Signer after that, here: https://github.com/kubernetes-sigs/promo-tools/blob/d8a1c646670799b0437aca6c56886a8483587197/internal/promoter/image/sign.go#L164

That identity token is added to SignOpts, however, a new Signer is not created after. That's what's causing the issue.

That's because of this function: https://github.com/kubernetes-sigs/release-sdk/blob/6fb808a54425bf8e2a9f1f57a9c7ec232692c65b/sign/sign.go#L146

It takes the identity token from the SignOpts in the Signer object, but we expect that it takes the identity token from the SignOpts provided to the `SignImageWithOptions`. I believe that's the reason why the signatures are incorrect.

This PR fixes that by creating a new Signer after obtaining and setting the identity token.

#### Which issue(s) this PR fixes:

None

The issue is being discussed on Slack: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1669761613115499

#### Does this PR introduce a user-facing change?
```release-note
Create a new signer after getting the identity token
```

/assign @puerco @saschagrunert 
cc @kubernetes-sigs/release-engineering 