### PR TITLE
Add a new issue template for cutting releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/cut-release.md
+++ b/.github/ISSUE_TEMPLATE/cut-release.md
@@ -1,0 +1,22 @@
+---
+name: Cut a new promo-tools release
+about: Create a tracking issue for a promo-tools release cut
+title: Release k-sigs/promo-tools@vX.Y.Z
+labels: sig/release, area/release-eng
+
+---
+
+### vX.Y.Z
+
+Issue track for the upcoming release of promo-tools X.Y.Z.
+
+<!-- Example: https://github.com/kubernetes-sigs/promo-tools/issues/682 -->
+<!-- Search query: https://github.com/kubernetes-sigs/promo-tools/issues?q=is%3Aissue+is%3Aclosed+Release+k-sigs%2Fpromo-tools -->
+Previous promo-tools release cut issue: <!-- insert previous release cut issue number -->
+
+- [ ] Release Prep:  <!-- Example: https://github.com/kubernetes-sigs/promo-tools/pull/676 -->
+- [ ] Release:  <!-- Example: https://github.com/kubernetes-sigs/promo-tools/releases/tag/v3.4.9 -->
+- [ ] Image promotion:  <!-- Example: https://github.com/kubernetes/k8s.io/pull/4446 -->
+- [ ] Rollout:  <!-- Example: https://github.com/kubernetes/test-infra/pull/27963 -->
+
+cc @kubernetes-sigs/release-engineering 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR adds a new issue template for cutting a new release of promo-tools.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @puerco 
cc @kubernetes-sigs/release-engineering 