### PR TITLE
Comment why we create a new Signer

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -167,6 +167,10 @@ func (di *DefaultPromoterImplementation) SignImages(
 	}
 	signOpts.IdentityToken = token
 
+	// Creating a new Signer after setting the identity token is MANDATORY
+	// because that's the only way to propagate the identity token to the
+	// internal Signer structs. Without that, the identity token wouldn't be
+	// used at all and images would be signed with a wrong identity.
 	di.signer = sign.New(signOpts)
 
 	// We only sign the first image of each edge. If there are more


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This is a follow-up on #681 to add a code comment describing why we need to create a new Signer after setting the identity token.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @puerco 