### PR TITLE
Add support for batch jobs

### DIFF
--- a/internal/legacy/dockerregistry/schema/manifest.go
+++ b/internal/legacy/dockerregistry/schema/manifest.go
@@ -333,6 +333,7 @@ func diffProwFiles(dir string) (digests []string, err error) {
 		jobTypeEnv        = "JOB_TYPE"
 		jobTypePostsubmit = "postsubmit"
 		jobTypePresubmit  = "presubmit"
+		jobTypeBatch      = "batch"
 	)
 
 	jobType := os.Getenv(jobTypeEnv)
@@ -341,7 +342,7 @@ func diffProwFiles(dir string) (digests []string, err error) {
 	}
 
 	var base string
-	if jobType == jobTypePresubmit {
+	if jobType == jobTypePresubmit || jobType == jobTypeBatch {
 		pullBaseSHA := os.Getenv(pullBaseSHAEnv)
 		if pullBaseSHA == "" {
 			return nil, fmt.Errorf("%s not set", pullBaseSHAEnv)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Prow can merge PRs in batches. In that case, only one set of presubmits is run and that set of presubmits tests all the PRs in a batch. This can be a very effective mechanism to speed up presubmits and reduce the time needed to merge PRs.

However, when presumbits are run in a batch, they're called `batch` instead of `presubmit`. This means that `prow.k8s.io/type` is `batch` instead of `presubmit`.

This difference is causing `kpromo` to fail with the following error:

```
time="12:43:05.387" level=info msg="PromoteImages start" diff=0s
time="12:43:05.387" level=warning msg="Not setting a service account" diff=0s
time="12:43:05.920" level=info msg="Parsing manifests" diff=533ms
time="12:43:05.921" level=info msg="Using prow diff" diff=0s
time="12:43:05.921" level=fatal msg="run `cip run`: promote images: parsing manifests: parsing thin manifest directory: get prow diff files: unknown job type: batch" diff=0s
```

This PR adds support for batch jobs to kpromo. This PR treats those jobs the same as presubmits. It should work because batch jobs also have the pull base ref (`PULL_BASE_SHA`) which we need in presubmits.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is not tested because I'm not really sure how can we test this.

#### Does this PR introduce a user-facing change?
```release-note
Add support for Batch ProwJobs
```

/assign @saschagrunert @cpanato @puerco 
cc @kubernetes-sigs/release-engineering 