### PR TITLE
WIP: Run file operations in parallel

### DIFF
--- a/cmd/kpromo/cmd/run/files.go
+++ b/cmd/kpromo/cmd/run/files.go
@@ -81,6 +81,13 @@ func init() {
 		"allow service account usage with gcloud calls",
 	)
 
+	filesCmd.PersistentFlags().IntVar(
+		&filesOpts.ParallelUploads,
+		"parallel",
+		filesOpts.ParallelUploads,
+		"upload files in parallel goroutines",
+	)
+
 	// TODO(kpromo): Consider marking manifest flags as required
 
 	RunCmd.AddCommand(filesCmd)


### PR DESCRIPTION
This can be much faster, particularly when copying smaller files.
