### PR TITLE
S3 promotion: support anonymous authentication

### DIFF
--- a/cmd/kpromo/cmd/run/files.go
+++ b/cmd/kpromo/cmd/run/files.go
@@ -78,7 +78,7 @@ func init() {
 		&filesOpts.UseServiceAccount,
 		"use-service-account",
 		filesOpts.UseServiceAccount,
-		"allow service account usage with gcloud calls",
+		"allow service account usage with gcloud and S3 calls",
 	)
 
 	// TODO(kpromo): Consider marking manifest flags as required


### PR DESCRIPTION
If we don't have AWS credentials (or don't want to use them), we need
to actively specify that rather than attempt credential discovery
which then fails with an error.

Reuse the `--use-service-acccount=false` flag for this meaning.

```release-note

When --use-service-account=false (which is the default), we will issue anonymous requests to AWS and ignore any AWS credentials.  This should be sufficient for dry-run, and ensures that dry-run is safe even if manifests are hostile.
```