### PR TITLE
kpromo sigcheck: Verify and fix missing image signatures

### DIFF
--- a/cmd/kpromo/cmd/root.go
+++ b/cmd/kpromo/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/mm"
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/pr"
 	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/run"
+	"sigs.k8s.io/promo-tools/v3/cmd/kpromo/cmd/sigcheck"
 	"sigs.k8s.io/release-utils/log"
 	"sigs.k8s.io/release-utils/version"
 )
@@ -84,6 +85,7 @@ func init() {
 	// TODO(cip-mm): Remove in the next minor release.
 	rootCmd.AddCommand(mm.MMCmd)
 	rootCmd.AddCommand(version.Version())
+	sigcheck.Add(rootCmd)
 }
 
 func initLogging(*cobra.Command, []string) error {

--- a/cmd/kpromo/cmd/sigcheck/sigcheck.go
+++ b/cmd/kpromo/cmd/sigcheck/sigcheck.go
@@ -54,5 +54,12 @@ to ensure copies in all mirrors have their signatures attached.
 		"when true, kpromo will sign and propagate missing signatures in images",
 	)
 
+	cmd.PersistentFlags().IntVar(
+		&opts.SignCheckDays,
+		"days",
+		5,
+		"check images uploaded this many days ago",
+	)
+
 	parent.AddCommand(cmd)
 }

--- a/cmd/kpromo/cmd/sigcheck/sigcheck.go
+++ b/cmd/kpromo/cmd/sigcheck/sigcheck.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sigcheck
+
+import (
+	"github.com/spf13/cobra"
+	imagepromoter "sigs.k8s.io/promo-tools/v3/promoter/image"
+	promoteropts "sigs.k8s.io/promo-tools/v3/promoter/image/options"
+)
+
+func Add(parent *cobra.Command) {
+	opts := &promoteropts.Options{}
+	cmd := &cobra.Command{
+		Use:   "sigcheck",
+		Short: "Check image signature consistency",
+		Long: `sigcheck - Check signature consistency across the K8s mirrors
+    
+This subcommand checks the signature consistency across promoted images
+to ensure copies in all mirrors have their signatures attached.
+    `,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.SignCheckReferences = args
+			}
+
+			p := imagepromoter.New()
+			if err := p.CheckSignatures(opts); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().BoolVar(
+		&opts.SignCheckFix,
+		"confirm",
+		false,
+		"when true, kpromo will sign and propagate missing signatures in images",
+	)
+
+	parent.AddCommand(cmd)
+}

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -121,7 +121,6 @@ func (di *DefaultPromoterImplementation) GetSignatureStatus(
 		for _, mirror := range mirrors {
 			rpath := repositoryPath
 			if strings.HasSuffix(mirror, ".gcr.io") {
-				logrus.Infof("Tiene: %s", mirror)
 				rpath = "k8s-artifacts-prod"
 			}
 

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -16,10 +16,27 @@ limitations under the License.
 
 package imagepromoter
 
-import options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
+)
 
 func (di *DefaultPromoterImplementation) GetLatestImages(opts *options.Options) ([]string, error) {
-
+	// If there is a list of images to check in the options
+	// we default to checking those.
+	if len(opts.SignCheckReferences) > 0 {
+		for _, refString := range opts.SignCheckReferences {
+			_, err := name.ParseReference(refString)
+			if err != nil {
+				return nil, fmt.Errorf("invalid image reference %s: %w", refString, err)
+			}
+		}
+		return opts.SignCheckReferences, nil
+	}
+	return nil, errors.New("Automatic image reader not yet implemented")
 }
 
 func (di *DefaultPromoterImplementation) GetSignatureStatus(opts *options.Options, images []string) ([]string, []string, []string, error) {

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,10 +19,22 @@ package imagepromoter
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 
+	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/release-utils/http"
+
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sirupsen/logrus"
+	checkresults "sigs.k8s.io/promo-tools/v3/promoter/image/checkresults"
 	options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 )
+
+var mirrorsList []string
+
+const repositoryPath = "k8s-artifacts-prod/images"
 
 func (di *DefaultPromoterImplementation) GetLatestImages(opts *options.Options) ([]string, error) {
 	// If there is a list of images to check in the options
@@ -39,14 +51,131 @@ func (di *DefaultPromoterImplementation) GetLatestImages(opts *options.Options) 
 	return nil, errors.New("Automatic image reader not yet implemented")
 }
 
-func (di *DefaultPromoterImplementation) GetSignatureStatus(opts *options.Options, images []string) ([]string, []string, []string, error) {
+func (di *DefaultPromoterImplementation) getMirrors() ([]string, error) {
+	if mirrorsList != nil {
+		return mirrorsList, nil
+	}
+	urls := []string{}
+	iurls := map[string]string{}
+	manifest, err := http.NewAgent().Get(
+		"https://github.com/kubernetes/k8s.io/raw/main/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("downloading promoter manifest: %w", err)
+	}
 
+	type entriesList struct {
+		Registries []struct {
+			Name string `yaml:"name,omitempty"`
+			Src  bool   `yaml:"src,omitempty"`
+		} `yaml:"registries"`
+	}
+
+	entries := entriesList{}
+	if err := yaml.Unmarshal(manifest, &entries); err != nil {
+		return nil, fmt.Errorf("unmarshalling promoter manifest: %w", err)
+	}
+
+	for _, e := range entries.Registries {
+		if e.Src {
+			continue
+		}
+		u, err := url.Parse("https://" + e.Name)
+		if err != nil {
+			return nil, fmt.Errorf("parsing url %s: %w", u, err)
+		}
+		iurls[u.Hostname()] = u.Hostname()
+	}
+
+	for u := range iurls {
+		urls = append(urls, u)
+	}
+	mirrorsList = urls
+	return urls, nil
 }
 
-func (di *DefaultPromoterImplementation) FixMissingSignatures(opts *options.Options, images []string) error {
+func (di *DefaultPromoterImplementation) GetSignatureStatus(
+	opts *options.Options, images []string,
+) (checkresults.Signature, error) {
+	results := checkresults.Signature{}
+	mirrors, err := di.getMirrors()
+	if err != nil {
+		return results, fmt.Errorf("reading mirrors: %w", err)
+	}
+	logrus.Infof("Checking signatures in %d mirrors", len(mirrors))
+	for _, refString := range images {
+		ref, err := name.ParseReference(refString)
+		if err != nil {
+			return results, fmt.Errorf("parsing reference: %w", err)
+		}
+		logrus.Info("Name: " + ref.Name())
+		logrus.Info("Identifier: " + ref.Identifier())
+		logrus.Info("Context Name: " + ref.Context().Name())
+		logrus.Info("Registry Name: " + ref.Context().RegistryStr())
+		logrus.Info("Repo Name: " + ref.Context().RepositoryStr())
 
+		digest, err := crane.Digest(refString)
+		if err != nil {
+			return results, fmt.Errorf("getting digest for %s: %w", refString, err)
+		}
+		logrus.Infof("image digest: %s", digest)
+
+		targetImages := []string{}
+		for _, mirror := range mirrors {
+			targetImages = append(targetImages, fmt.Sprintf("%s/%s/%s:%s.sig",
+				mirror, repositoryPath, ref.Context().RepositoryStr(),
+				strings.ReplaceAll(digest, ":", "-"),
+			))
+		}
+		existing, missing, err := checkObjects(targetImages)
+		if err != nil {
+			return results, fmt.Errorf("checking objects: %w", err)
+		}
+		results[refString] = checkresults.CheckList{
+			Signed:  existing,
+			Missing: missing,
+		}
+	}
+	return results, nil
 }
 
-func (di *DefaultPromoterImplementation) FixPartialSignatures(opts *options.Options, images []string) error {
+func checkObjects(oList []string) (existing, missing []string, err error) {
+	existing = []string{}
+	missing = []string{}
+	for _, s := range oList {
+		e, err := objectExists(s)
+		if err != nil {
+			return existing, missing, fmt.Errorf("checking reference: %w", err)
+		}
 
+		if e {
+			existing = append(existing, s)
+		} else {
+			missing = append(missing, s)
+		}
+		break
+	}
+	return existing, missing, nil
+}
+
+func objectExists(refString string) (bool, error) {
+	// Check
+	_, err := crane.Digest(refString)
+	if err == nil {
+		return true, nil
+	}
+
+	if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("checking if reference exists in the registry: %w", err)
+}
+
+func (di *DefaultPromoterImplementation) FixMissingSignatures(opts *options.Options, results checkresults.Signature) error {
+	return nil
+}
+
+func (di *DefaultPromoterImplementation) FixPartialSignatures(opts *options.Options, results checkresults.Signature) error {
+	return nil
 }

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagepromoter
+
+import options "sigs.k8s.io/promo-tools/v3/promoter/image/options"
+
+func (di *DefaultPromoterImplementation) GetLatestImages(opts *options.Options) ([]string, error) {
+
+}
+
+func (di *DefaultPromoterImplementation) GetSignatureStatus(opts *options.Options, images []string) ([]string, []string, []string, error) {
+
+}
+
+func (di *DefaultPromoterImplementation) FixMissingSignatures(opts *options.Options, images []string) error {
+
+}
+
+func (di *DefaultPromoterImplementation) FixPartialSignatures(opts *options.Options, images []string) error {
+
+}

--- a/promoter/image/checkresults/checkresults.go
+++ b/promoter/image/checkresults/checkresults.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package checkresults
+
+type CheckList = struct {
+	Signed  []string
+	Missing []string
+}
+
+type Signature map[string]CheckList
+
+func (s *Signature) TotalPartial() int {
+	total := 0
+	for _, list := range *s {
+		if len(list.Missing) == 0 || len(list.Missing) == len(list.Signed) {
+			continue
+		}
+		total++
+	}
+	return total
+}
+
+func (s *Signature) TotalUnsigned() int {
+	total := 0
+	for _, list := range *s {
+		if len(list.Missing) > 0 && len(list.Signed) == 0 {
+			total++
+		}
+	}
+	return total
+}

--- a/promoter/image/checkresults/checkresults.go
+++ b/promoter/image/checkresults/checkresults.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package checkresults
 
 type CheckList struct {

--- a/promoter/image/checkresults/checkresults.go
+++ b/promoter/image/checkresults/checkresults.go
@@ -15,9 +15,10 @@ limitations under the License.
 */
 package checkresults
 
-type CheckList = struct {
-	Signed  []string
-	Missing []string
+type CheckList struct {
+	SignatureImage string
+	Signed         []string
+	Missing        []string
 }
 
 type Signature map[string]CheckList
@@ -25,10 +26,9 @@ type Signature map[string]CheckList
 func (s *Signature) TotalPartial() int {
 	total := 0
 	for _, list := range *s {
-		if len(list.Missing) == 0 || len(list.Missing) == len(list.Signed) {
-			continue
+		if len(list.Signed) > 0 && len(list.Missing) > 0 {
+			total++
 		}
-		total++
 	}
 	return total
 }

--- a/promoter/image/checkresults/checkresults.go
+++ b/promoter/image/checkresults/checkresults.go
@@ -16,9 +16,8 @@ limitations under the License.
 package checkresults
 
 type CheckList struct {
-	SignatureImage string
-	Signed         []string
-	Missing        []string
+	Signed  []string
+	Missing []string
 }
 
 type Signature map[string]CheckList

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/registry"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/dockerregistry/schema"
 	imagepromoterb "sigs.k8s.io/promo-tools/v3/internal/promoter/image"
+	"sigs.k8s.io/promo-tools/v3/promoter/image/checkresults"
 	imagepromotera "sigs.k8s.io/promo-tools/v3/promoter/image/options"
 )
 
@@ -66,6 +67,43 @@ type FakePromoterImplementation struct {
 	copySignaturesReturnsOnCall map[int]struct {
 		result1 error
 	}
+	FixMissingSignaturesStub        func(*imagepromotera.Options, checkresults.Signature) error
+	fixMissingSignaturesMutex       sync.RWMutex
+	fixMissingSignaturesArgsForCall []struct {
+		arg1 *imagepromotera.Options
+		arg2 checkresults.Signature
+	}
+	fixMissingSignaturesReturns struct {
+		result1 error
+	}
+	fixMissingSignaturesReturnsOnCall map[int]struct {
+		result1 error
+	}
+	FixPartialSignaturesStub        func(*imagepromotera.Options, checkresults.Signature) error
+	fixPartialSignaturesMutex       sync.RWMutex
+	fixPartialSignaturesArgsForCall []struct {
+		arg1 *imagepromotera.Options
+		arg2 checkresults.Signature
+	}
+	fixPartialSignaturesReturns struct {
+		result1 error
+	}
+	fixPartialSignaturesReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GetLatestImagesStub        func(*imagepromotera.Options) ([]string, error)
+	getLatestImagesMutex       sync.RWMutex
+	getLatestImagesArgsForCall []struct {
+		arg1 *imagepromotera.Options
+	}
+	getLatestImagesReturns struct {
+		result1 []string
+		result2 error
+	}
+	getLatestImagesReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
 	GetPromotionEdgesStub        func(*inventory.SyncContext, []schema.Manifest) (map[inventory.PromotionEdge]interface{}, error)
 	getPromotionEdgesMutex       sync.RWMutex
 	getPromotionEdgesArgsForCall []struct {
@@ -92,6 +130,20 @@ type FakePromoterImplementation struct {
 	}
 	getRegistryImageInventoryReturnsOnCall map[int]struct {
 		result1 registry.RegInvImage
+		result2 error
+	}
+	GetSignatureStatusStub        func(*imagepromotera.Options, []string) (checkresults.Signature, error)
+	getSignatureStatusMutex       sync.RWMutex
+	getSignatureStatusArgsForCall []struct {
+		arg1 *imagepromotera.Options
+		arg2 []string
+	}
+	getSignatureStatusReturns struct {
+		result1 checkresults.Signature
+		result2 error
+	}
+	getSignatureStatusReturnsOnCall map[int]struct {
+		result1 checkresults.Signature
 		result2 error
 	}
 	GetSnapshotManifestsStub        func(*imagepromotera.Options) ([]schema.Manifest, error)
@@ -491,6 +543,194 @@ func (fake *FakePromoterImplementation) CopySignaturesReturnsOnCall(i int, resul
 	}{result1}
 }
 
+func (fake *FakePromoterImplementation) FixMissingSignatures(arg1 *imagepromotera.Options, arg2 checkresults.Signature) error {
+	fake.fixMissingSignaturesMutex.Lock()
+	ret, specificReturn := fake.fixMissingSignaturesReturnsOnCall[len(fake.fixMissingSignaturesArgsForCall)]
+	fake.fixMissingSignaturesArgsForCall = append(fake.fixMissingSignaturesArgsForCall, struct {
+		arg1 *imagepromotera.Options
+		arg2 checkresults.Signature
+	}{arg1, arg2})
+	stub := fake.FixMissingSignaturesStub
+	fakeReturns := fake.fixMissingSignaturesReturns
+	fake.recordInvocation("FixMissingSignatures", []interface{}{arg1, arg2})
+	fake.fixMissingSignaturesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePromoterImplementation) FixMissingSignaturesCallCount() int {
+	fake.fixMissingSignaturesMutex.RLock()
+	defer fake.fixMissingSignaturesMutex.RUnlock()
+	return len(fake.fixMissingSignaturesArgsForCall)
+}
+
+func (fake *FakePromoterImplementation) FixMissingSignaturesCalls(stub func(*imagepromotera.Options, checkresults.Signature) error) {
+	fake.fixMissingSignaturesMutex.Lock()
+	defer fake.fixMissingSignaturesMutex.Unlock()
+	fake.FixMissingSignaturesStub = stub
+}
+
+func (fake *FakePromoterImplementation) FixMissingSignaturesArgsForCall(i int) (*imagepromotera.Options, checkresults.Signature) {
+	fake.fixMissingSignaturesMutex.RLock()
+	defer fake.fixMissingSignaturesMutex.RUnlock()
+	argsForCall := fake.fixMissingSignaturesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePromoterImplementation) FixMissingSignaturesReturns(result1 error) {
+	fake.fixMissingSignaturesMutex.Lock()
+	defer fake.fixMissingSignaturesMutex.Unlock()
+	fake.FixMissingSignaturesStub = nil
+	fake.fixMissingSignaturesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePromoterImplementation) FixMissingSignaturesReturnsOnCall(i int, result1 error) {
+	fake.fixMissingSignaturesMutex.Lock()
+	defer fake.fixMissingSignaturesMutex.Unlock()
+	fake.FixMissingSignaturesStub = nil
+	if fake.fixMissingSignaturesReturnsOnCall == nil {
+		fake.fixMissingSignaturesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.fixMissingSignaturesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePromoterImplementation) FixPartialSignatures(arg1 *imagepromotera.Options, arg2 checkresults.Signature) error {
+	fake.fixPartialSignaturesMutex.Lock()
+	ret, specificReturn := fake.fixPartialSignaturesReturnsOnCall[len(fake.fixPartialSignaturesArgsForCall)]
+	fake.fixPartialSignaturesArgsForCall = append(fake.fixPartialSignaturesArgsForCall, struct {
+		arg1 *imagepromotera.Options
+		arg2 checkresults.Signature
+	}{arg1, arg2})
+	stub := fake.FixPartialSignaturesStub
+	fakeReturns := fake.fixPartialSignaturesReturns
+	fake.recordInvocation("FixPartialSignatures", []interface{}{arg1, arg2})
+	fake.fixPartialSignaturesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePromoterImplementation) FixPartialSignaturesCallCount() int {
+	fake.fixPartialSignaturesMutex.RLock()
+	defer fake.fixPartialSignaturesMutex.RUnlock()
+	return len(fake.fixPartialSignaturesArgsForCall)
+}
+
+func (fake *FakePromoterImplementation) FixPartialSignaturesCalls(stub func(*imagepromotera.Options, checkresults.Signature) error) {
+	fake.fixPartialSignaturesMutex.Lock()
+	defer fake.fixPartialSignaturesMutex.Unlock()
+	fake.FixPartialSignaturesStub = stub
+}
+
+func (fake *FakePromoterImplementation) FixPartialSignaturesArgsForCall(i int) (*imagepromotera.Options, checkresults.Signature) {
+	fake.fixPartialSignaturesMutex.RLock()
+	defer fake.fixPartialSignaturesMutex.RUnlock()
+	argsForCall := fake.fixPartialSignaturesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePromoterImplementation) FixPartialSignaturesReturns(result1 error) {
+	fake.fixPartialSignaturesMutex.Lock()
+	defer fake.fixPartialSignaturesMutex.Unlock()
+	fake.FixPartialSignaturesStub = nil
+	fake.fixPartialSignaturesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePromoterImplementation) FixPartialSignaturesReturnsOnCall(i int, result1 error) {
+	fake.fixPartialSignaturesMutex.Lock()
+	defer fake.fixPartialSignaturesMutex.Unlock()
+	fake.FixPartialSignaturesStub = nil
+	if fake.fixPartialSignaturesReturnsOnCall == nil {
+		fake.fixPartialSignaturesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.fixPartialSignaturesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePromoterImplementation) GetLatestImages(arg1 *imagepromotera.Options) ([]string, error) {
+	fake.getLatestImagesMutex.Lock()
+	ret, specificReturn := fake.getLatestImagesReturnsOnCall[len(fake.getLatestImagesArgsForCall)]
+	fake.getLatestImagesArgsForCall = append(fake.getLatestImagesArgsForCall, struct {
+		arg1 *imagepromotera.Options
+	}{arg1})
+	stub := fake.GetLatestImagesStub
+	fakeReturns := fake.getLatestImagesReturns
+	fake.recordInvocation("GetLatestImages", []interface{}{arg1})
+	fake.getLatestImagesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePromoterImplementation) GetLatestImagesCallCount() int {
+	fake.getLatestImagesMutex.RLock()
+	defer fake.getLatestImagesMutex.RUnlock()
+	return len(fake.getLatestImagesArgsForCall)
+}
+
+func (fake *FakePromoterImplementation) GetLatestImagesCalls(stub func(*imagepromotera.Options) ([]string, error)) {
+	fake.getLatestImagesMutex.Lock()
+	defer fake.getLatestImagesMutex.Unlock()
+	fake.GetLatestImagesStub = stub
+}
+
+func (fake *FakePromoterImplementation) GetLatestImagesArgsForCall(i int) *imagepromotera.Options {
+	fake.getLatestImagesMutex.RLock()
+	defer fake.getLatestImagesMutex.RUnlock()
+	argsForCall := fake.getLatestImagesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakePromoterImplementation) GetLatestImagesReturns(result1 []string, result2 error) {
+	fake.getLatestImagesMutex.Lock()
+	defer fake.getLatestImagesMutex.Unlock()
+	fake.GetLatestImagesStub = nil
+	fake.getLatestImagesReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePromoterImplementation) GetLatestImagesReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.getLatestImagesMutex.Lock()
+	defer fake.getLatestImagesMutex.Unlock()
+	fake.GetLatestImagesStub = nil
+	if fake.getLatestImagesReturnsOnCall == nil {
+		fake.getLatestImagesReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.getLatestImagesReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakePromoterImplementation) GetPromotionEdges(arg1 *inventory.SyncContext, arg2 []schema.Manifest) (map[inventory.PromotionEdge]interface{}, error) {
 	var arg2Copy []schema.Manifest
 	if arg2 != nil {
@@ -627,6 +867,76 @@ func (fake *FakePromoterImplementation) GetRegistryImageInventoryReturnsOnCall(i
 	}
 	fake.getRegistryImageInventoryReturnsOnCall[i] = struct {
 		result1 registry.RegInvImage
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePromoterImplementation) GetSignatureStatus(arg1 *imagepromotera.Options, arg2 []string) (checkresults.Signature, error) {
+	var arg2Copy []string
+	if arg2 != nil {
+		arg2Copy = make([]string, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.getSignatureStatusMutex.Lock()
+	ret, specificReturn := fake.getSignatureStatusReturnsOnCall[len(fake.getSignatureStatusArgsForCall)]
+	fake.getSignatureStatusArgsForCall = append(fake.getSignatureStatusArgsForCall, struct {
+		arg1 *imagepromotera.Options
+		arg2 []string
+	}{arg1, arg2Copy})
+	stub := fake.GetSignatureStatusStub
+	fakeReturns := fake.getSignatureStatusReturns
+	fake.recordInvocation("GetSignatureStatus", []interface{}{arg1, arg2Copy})
+	fake.getSignatureStatusMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePromoterImplementation) GetSignatureStatusCallCount() int {
+	fake.getSignatureStatusMutex.RLock()
+	defer fake.getSignatureStatusMutex.RUnlock()
+	return len(fake.getSignatureStatusArgsForCall)
+}
+
+func (fake *FakePromoterImplementation) GetSignatureStatusCalls(stub func(*imagepromotera.Options, []string) (checkresults.Signature, error)) {
+	fake.getSignatureStatusMutex.Lock()
+	defer fake.getSignatureStatusMutex.Unlock()
+	fake.GetSignatureStatusStub = stub
+}
+
+func (fake *FakePromoterImplementation) GetSignatureStatusArgsForCall(i int) (*imagepromotera.Options, []string) {
+	fake.getSignatureStatusMutex.RLock()
+	defer fake.getSignatureStatusMutex.RUnlock()
+	argsForCall := fake.getSignatureStatusArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePromoterImplementation) GetSignatureStatusReturns(result1 checkresults.Signature, result2 error) {
+	fake.getSignatureStatusMutex.Lock()
+	defer fake.getSignatureStatusMutex.Unlock()
+	fake.GetSignatureStatusStub = nil
+	fake.getSignatureStatusReturns = struct {
+		result1 checkresults.Signature
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePromoterImplementation) GetSignatureStatusReturnsOnCall(i int, result1 checkresults.Signature, result2 error) {
+	fake.getSignatureStatusMutex.Lock()
+	defer fake.getSignatureStatusMutex.Unlock()
+	fake.GetSignatureStatusStub = nil
+	if fake.getSignatureStatusReturnsOnCall == nil {
+		fake.getSignatureStatusReturnsOnCall = make(map[int]struct {
+			result1 checkresults.Signature
+			result2 error
+		})
+	}
+	fake.getSignatureStatusReturnsOnCall[i] = struct {
+		result1 checkresults.Signature
 		result2 error
 	}{result1, result2}
 }
@@ -1664,10 +1974,18 @@ func (fake *FakePromoterImplementation) Invocations() map[string][][]interface{}
 	defer fake.appendManifestToSnapshotMutex.RUnlock()
 	fake.copySignaturesMutex.RLock()
 	defer fake.copySignaturesMutex.RUnlock()
+	fake.fixMissingSignaturesMutex.RLock()
+	defer fake.fixMissingSignaturesMutex.RUnlock()
+	fake.fixPartialSignaturesMutex.RLock()
+	defer fake.fixPartialSignaturesMutex.RUnlock()
+	fake.getLatestImagesMutex.RLock()
+	defer fake.getLatestImagesMutex.RUnlock()
 	fake.getPromotionEdgesMutex.RLock()
 	defer fake.getPromotionEdgesMutex.RUnlock()
 	fake.getRegistryImageInventoryMutex.RLock()
 	defer fake.getRegistryImageInventoryMutex.RUnlock()
+	fake.getSignatureStatusMutex.RLock()
+	defer fake.getSignatureStatusMutex.RUnlock()
 	fake.getSnapshotManifestsMutex.RLock()
 	defer fake.getSnapshotManifestsMutex.RUnlock()
 	fake.getSnapshotSourceRegistryMutex.RLock()

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -105,6 +105,9 @@ type Options struct {
 
 	// SignCheckReferences list of image references to check for signatures
 	SignCheckReferences []string
+
+	// SignCheckFix when true, fix missing signatures
+	SignCheckFix bool
 }
 
 var DefaultOptions = &Options{
@@ -114,6 +117,7 @@ var DefaultOptions = &Options{
 	SeverityThreshold:   -1,
 	SignImages:          true,
 	SignerAccount:       "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
+	SignCheckFix:        false,
 	SignCheckReferences: []string{},
 }
 

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -108,6 +108,9 @@ type Options struct {
 
 	// SignCheckFix when true, fix missing signatures
 	SignCheckFix bool
+
+	// SignCheckDays number of days back to check for signatrures
+	SignCheckDays int
 }
 
 var DefaultOptions = &Options{
@@ -119,6 +122,7 @@ var DefaultOptions = &Options{
 	SignerAccount:       "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
 	SignCheckFix:        false,
 	SignCheckReferences: []string{},
+	SignCheckDays:       5,
 }
 
 func (o *Options) Validate() error {

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -102,15 +102,19 @@ type Options struct {
 	// If this credentials file is not set, the promoter will attempt to generate
 	// the OIDC tokens getting its identity from the default application credentials.
 	SignerInitCredentials string
+
+	// SignCheckReferences list of image references to check for signatures
+	SignCheckReferences []string
 }
 
 var DefaultOptions = &Options{
-	OutputFormat:      "yaml",
-	MaxImageSize:      2048,
-	Threads:           10,
-	SeverityThreshold: -1,
-	SignImages:        true,
-	SignerAccount:     "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
+	OutputFormat:        "yaml",
+	MaxImageSize:        2048,
+	Threads:             10,
+	SeverityThreshold:   -1,
+	SignImages:          true,
+	SignerAccount:       "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
+	SignCheckReferences: []string{},
 }
 
 func (o *Options) Validate() error {

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -79,7 +79,7 @@ type promoterImplementation interface {
 	ScanEdges(*options.Options, *reg.SyncContext, map[reg.PromotionEdge]interface{}) error
 
 	// Methods for manifest list verification:
-	ValidateManifestLists(opts *options.Options) error
+	ValidateManifestLists(*options.Options) error
 
 	// Methods for image signing
 	PrewarmTUFCache() error
@@ -87,6 +87,12 @@ type promoterImplementation interface {
 	CopySignatures(*options.Options, *reg.SyncContext, map[reg.PromotionEdge]interface{}) error
 	SignImages(*options.Options, *reg.SyncContext, map[reg.PromotionEdge]interface{}) error
 	WriteSBOMs(*options.Options, *reg.SyncContext, map[reg.PromotionEdge]interface{}) error
+
+	// Methods for checking signatures
+	GetLatestImages(*options.Options) ([]string, error)
+	GetSignatureStatus(*options.Options, []string) ([]string, []string, []string, error)
+	FixMissingSignatures(*options.Options, []string) error
+	FixPartialSignatures(*options.Options, []string) error
 
 	// Utility functions
 	PrintVersion()
@@ -278,5 +284,38 @@ func (p *Promoter) CheckManifestLists(opts *options.Options) error {
 	if err := p.impl.ValidateManifestLists(opts); err != nil {
 		return fmt.Errorf("checking manifest lists: %w", err)
 	}
+	return nil
+}
+
+// CheckSignatures checks the consistency of a set of images
+func (p *Promoter) CheckSignatures(opts *options.Options) error {
+	logrus.Info("Fetching latest promoted images")
+	images, err := p.impl.GetLatestImages(opts)
+	if err != nil {
+		return fmt.Errorf("getting latest promoted images: %w", err)
+	}
+
+	logrus.Info("Checking signatures")
+	signed, partial, missing, err := p.impl.GetSignatureStatus(opts, images)
+	if err != nil {
+		return fmt.Errorf("checking signature status in images: %w", err)
+	}
+
+	logrus.Infof("%d/%d images with consitent signatures", len(signed), len(images))
+	if len(partial) == 0 && len(missing) == 0 {
+		logrus.Info("Signature consistency OK!")
+		return nil
+	}
+
+	logrus.Infof("Fixing %d missing signatures", len(missing))
+	if err := p.impl.FixMissingSignatures(opts, missing); err != nil {
+		return fmt.Errorf("fixing missing signatures: %w", err)
+	}
+
+	logrus.Infof("Fixing %d partial signatures", len(partial))
+	if err := p.impl.FixPartialSignatures(opts, partial); err != nil {
+		return fmt.Errorf("fixing partial signatures: %w", err)
+	}
+
 	return nil
 }

--- a/promoter/image/promoter.go
+++ b/promoter/image/promoter.go
@@ -307,12 +307,12 @@ func (p *Promoter) CheckSignatures(opts *options.Options) error {
 		return nil
 	}
 
-	logrus.Infof("Fixing %d missing signatures", results.TotalUnsigned())
+	logrus.Infof("Fixing %d unsigned images", results.TotalUnsigned())
 	if err := p.impl.FixMissingSignatures(opts, results); err != nil {
 		return fmt.Errorf("fixing missing signatures: %w", err)
 	}
 
-	logrus.Infof("Fixing %d partial signatures", results.TotalPartial())
+	logrus.Infof("Fixing %d images with partial signatures", results.TotalPartial())
 	if err := p.impl.FixPartialSignatures(opts, results); err != nil {
 		return fmt.Errorf("fixing partial signatures: %w", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR introduces a new `kpromo sigcheck` subcommand that checks images for missing or inconsistent
signatures. Without passing the `--confirm` flag, kpromo will only check the signatures and output a dry run
of what it would do.

`kpromo sigcheck` takes image references as positional arguments, if not specified, it will check all the latest images uploaded to the kubernetes registry.

#### Which issue(s) this PR fixes:

This is intended to be a periodic job that ensures that images are properly signed.

#### Special notes for your reviewer:

**Note** this change is a different code path than the usual image promotion. So it should not affect any current process

Signing and replicating are untested for now, although it is mostly the same code we already had. We need to write some tests too.

To test the verification, run `kpromo` from my branch and test against the images, without `--confirm` nothing is changed. For example, this is an image missing signatures, and the next one is properly signed:

```
go run ./cmd/kpromo/ sigcheck registry.k8s.io/kube-scheduler:v1.24.11
NFO Fetching latest promoted images              
INFO Checking signatures                          
INFO Sending GET request to https://github.com/kubernetes/k8s.io/raw/main/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml 
INFO Checking signatures in 23 mirrors            
INFO Checking 23 objects for signatures           
INFO Fixing 1 unsigned images                     
``

```
go run ./cmd/kpromo/ sigcheck registry.k8s.io/kube-scheduler:v1.24.10
INFO Fetching latest promoted images              
INFO Checking signatures                          
INFO Sending GET request to https://github.com/kubernetes/k8s.io/raw/main/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml 
INFO Checking signatures in 23 mirrors            
INFO Checking 23 objects for signatures           
INFO Signature consistency OK!                 
```

#### Does this PR introduce a user-facing change?


```release-note
New `kpromo sigcheck` subcommand to verify and optionally fix images that may hay missing or inconsistent signatures.
```
