### PR TITLE
Replace k8s.gcr.io references with registry.k8s.io

### DIFF
--- a/cmd/kpromo/cmd/pr/pr.go
+++ b/cmd/kpromo/cmd/pr/pr.go
@@ -203,7 +203,7 @@ func runPromote(opts *promoteOptions) error {
 
 	// Path to the promoter image list
 	imagesListPath := filepath.Join(
-		image.ProdRegistry,
+		image.ProdRegistryLegacy,
 		"images",
 		filepath.Base(image.StagingRepoPrefix)+opts.project,
 		"images.yaml",
@@ -224,7 +224,7 @@ func runPromote(opts *promoteOptions) error {
 
 		opt := manifest.GrowOptions{}
 		if err := opt.Populate(
-			filepath.Join(repo.Dir(), image.ProdRegistry),
+			filepath.Join(repo.Dir(), image.ProdRegistryLegacy),
 			image.StagingRepoPrefix+opts.project, opts.images, opts.digests, opts.tags); err != nil {
 			return fmt.Errorf("populating image promoter options for tag %s with image filter %s: %w", opts.tags, opts.images, err)
 		}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -56,7 +56,7 @@ dependencies:
     - path: go.mod
       match: go \d+.\d+
 
-  - name: "k8s.gcr.io/artifact-promoter/kpromo"
+  - name: "registry.k8s.io/artifact-promoter/kpromo"
     version: v3.4.12-1
     refPaths:
     - path: cloudbuild.yaml

--- a/image/image.go
+++ b/image/image.go
@@ -29,7 +29,10 @@ import (
 
 const (
 	// Production registry root URL
-	ProdRegistry = "k8s.gcr.io"
+	ProdRegistry = "registry.k8s.io"
+
+	// Production registry root URL (legacy k8s.gcr.io)
+	ProdRegistryLegacy = "k8s.gcr.io"
 
 	// Staging repository root URL prefix
 	StagingRepoPrefix = "gcr.io/k8s-staging-"

--- a/internal/legacy/dockerregistry/inventory.go
+++ b/internal/legacy/dockerregistry/inventory.go
@@ -694,7 +694,7 @@ func ParseContainerParts(s string) (
 		}
 		return strings.Join(parts[0:2], "/"), strings.Join(parts[2:], "/"), nil
 	default:
-		if parts[0] != "k8s.gcr.io" && parts[0] != "staging-k8s.gcr.io" {
+		if parts[0] != "k8s.gcr.io" && parts[0] != "staging-k8s.gcr.io" && parts[0] != "registry.k8s.io" {
 			goto InvalidString
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

This PR does three things as part of https://github.com/kubernetes/k8s.io/issues/4738:

- Add registry.k8s.io to `internal/legacy/dockerregistry`
  - I'm not sure if that's needed or how's that code used at all, but we have k8s.gcr.io there and looking by how that function is used, it makes sense _to me_
  - I'm happy to revert this commit if needed because I'm not sure if it makes any sense
  - I also added some tests cases based on `registry.k8s.io`
- Use registry.k8s.io in dependencies.yaml
  - This should be just a cosmetic change
- Point ProdRegistry to registry.k8s.io and add ProdRegistryLegacy that points to k8s.gcr.io
  - This is the most important change. We use this const in krel when validating images: https://github.com/kubernetes/release/blob/eea315df4938e5687ae571eee1019c229eb3575d/pkg/anago/release.go#L419
  - As we'll not push to k8s.gcr.io any longer, we need to change it to registry.k8s.io otherwise we'll fail to validate if images are pushed
  - I thought the best way to accomplish this is to change the underlying const
  - To cover the cases where we need the old value, I added ProdRegistryLegacy. I also did a search with cs.k8s.io to ensure that no other project uses ProdRegistry variable

There are some other `k8s.gcr.io` references, but those make sense and are still needed, so I left them in place.

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/k8s.io/issues/4738

#### Does this PR introduce a user-facing change?
```release-note
ProdRegistry const is changed to `registry.k8s.io`. A new const called ProdRegistryLegacy is introduced and it points to `k8s.gcr.io`
```

/assign @saschagrunert @cpanato @puerco 
cc @kubernetes-sigs/release-engineering 