### PR TITLE
Signature Check: Check Expected Identity in Certificate

### DIFF
--- a/cmd/kpromo/cmd/sigcheck/sigcheck.go
+++ b/cmd/kpromo/cmd/sigcheck/sigcheck.go
@@ -58,7 +58,14 @@ to ensure copies in all mirrors have their signatures attached.
 		&opts.SignCheckFromDays,
 		"from-days",
 		5,
-		"check images uploaded this many days ago",
+		"check images uploaded starting this many days ago",
+	)
+
+	cmd.PersistentFlags().IntVar(
+		&opts.SignCheckToDays,
+		"to-days",
+		0,
+		"check images --from-days ago to this many days ago (defaults to today)",
 	)
 
 	parent.AddCommand(cmd)

--- a/cmd/kpromo/cmd/sigcheck/sigcheck.go
+++ b/cmd/kpromo/cmd/sigcheck/sigcheck.go
@@ -31,6 +31,21 @@ func Add(parent *cobra.Command) {
     
 This subcommand checks the signature consistency across promoted images
 to ensure copies in all mirrors have their signatures attached.
+
+By default, kpromo sigcheck will look at all images promoted during the last
+%d days. You can change the default using --from-days and determine a range
+using --to-days. For example, to verify all images promoted in an interval
+between 10 and 5 days ago run:
+
+   kpromo sigcheck --from-days=10 --to-days=5
+
+To debug the signature checker, you can limit the number of images kpromo
+verifies using --limit. When no limit is specified, kpromo will check the
+signatures of all images in the specified date range. As an example, to limit
+kpromo to the first three images it finds run:
+
+   kpromo sigcheck --limit=3
+
     `,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -66,6 +81,13 @@ to ensure copies in all mirrors have their signatures attached.
 		"to-days",
 		0,
 		"check images --from-days ago to this many days ago (defaults to today)",
+	)
+
+	cmd.PersistentFlags().IntVar(
+		&opts.SignCheckMaxImages,
+		"limit",
+		0,
+		"limit signature checks to a number of images (defaults to checking all)",
 	)
 
 	parent.AddCommand(cmd)

--- a/cmd/kpromo/cmd/sigcheck/sigcheck.go
+++ b/cmd/kpromo/cmd/sigcheck/sigcheck.go
@@ -55,8 +55,8 @@ to ensure copies in all mirrors have their signatures attached.
 	)
 
 	cmd.PersistentFlags().IntVar(
-		&opts.SignCheckDays,
-		"days",
+		&opts.SignCheckFromDays,
+		"from-days",
 		5,
 		"check images uploaded this many days ago",
 	)

--- a/cmd/kpromo/cmd/sigcheck/sigcheck.go
+++ b/cmd/kpromo/cmd/sigcheck/sigcheck.go
@@ -72,7 +72,7 @@ kpromo to the first three images it finds run:
 	cmd.PersistentFlags().IntVar(
 		&opts.SignCheckFromDays,
 		"from-days",
-		5,
+		promoteropts.DefaultOptions.SignCheckFromDays,
 		"check images uploaded starting this many days ago",
 	)
 
@@ -88,6 +88,20 @@ kpromo to the first three images it finds run:
 		"limit",
 		0,
 		"limit signature checks to a number of images (defaults to checking all)",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&opts.SignCheckIdentity,
+		"certificate-identity",
+		promoteropts.DefaultOptions.SignCheckIdentity,
+		"identity to look for when verifying signatures",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&opts.SignCheckIssuer,
+		"certificate-oidc-issuer",
+		promoteropts.DefaultOptions.SignCheckIssuer,
+		"issuer of the OIDC token used to generate the signature certificate",
 	)
 
 	parent.AddCommand(cmd)

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -305,6 +305,14 @@ func (di *DefaultPromoterImplementation) readLatestImages(opts *options.Options)
 	))
 
 	dateCutOff := time.Now().AddDate(0, 0, opts.SignCheckFromDays*-1)
+	dateCutOffTo := time.Now()
+	if opts.SignCheckToDays > 0 {
+		dateCutOffTo = time.Now().AddDate(0, 0, opts.SignCheckToDays*-1)
+	}
+	logrus.Infof("Checking images from %s to %s",
+		dateCutOff.Local().Format(time.RFC822),
+		dateCutOffTo.Local().Format(time.RFC822),
+	)
 	images := []string{}
 
 	repo, err := name.NewRepository(scanRegistry+"/"+repositoryPath, name.WeakValidation)
@@ -339,6 +347,10 @@ func (di *DefaultPromoterImplementation) readLatestImages(opts *options.Options)
 
 			// Ignore if uploaded before our date
 			if manifest.Uploaded.Before(dateCutOff) {
+				continue
+			}
+
+			if opts.SignCheckToDays > 0 && manifest.Uploaded.After(dateCutOffTo) {
 				continue
 			}
 

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -64,7 +64,7 @@ func (di *DefaultPromoterImplementation) GetLatestImages(opts *options.Options) 
 	if err != nil {
 		return nil, fmt.Errorf("fetching latest images: %w", err)
 	}
-	logrus.Infof("+%v", images)
+	logrus.Infof("Images to check: +%v", images)
 	return images, nil
 }
 
@@ -366,6 +366,10 @@ func (di *DefaultPromoterImplementation) readLatestImages(opts *options.Options)
 
 	if err := google.Walk(repo, walkFn, creds); err != nil {
 		return nil, fmt.Errorf("walking repo: %w", err)
+	}
+
+	if opts.SignCheckMaxImages != 0 {
+		images = images[0:opts.SignCheckMaxImages]
 	}
 
 	return images, nil

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -304,7 +304,7 @@ func (di *DefaultPromoterImplementation) readLatestImages(opts *options.Options)
 		google.Keychain,
 	))
 
-	dateCutOff := time.Now().AddDate(0, 0, opts.SignCheckDays*-1)
+	dateCutOff := time.Now().AddDate(0, 0, opts.SignCheckFromDays*-1)
 	images := []string{}
 
 	repo, err := name.NewRepository(scanRegistry+"/"+repositoryPath, name.WeakValidation)

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -234,18 +234,18 @@ func objectExists(opts *options.Options, refString string) (bool, error) {
 		}
 
 		names := cryptoutils.GetSubjectAlternateNames(certs[0])
-
 		for _, n := range names {
 			if n == opts.SignCheckIdentity {
 				return true, nil
 			}
 		}
+		signedLayers++
 	}
 
 	if signedLayers == 0 {
-		logrus.WithField("image", refString).Info("No certificates found")
+		logrus.WithField("image", refString).Debugf("No certificates found")
 	} else {
-		logrus.WithField("image", refString).Info("Image signed, but not with expected identity")
+		logrus.WithField("image", refString).Debugf("Image signed, but not with expected identity")
 	}
 
 	return false, nil

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -117,6 +117,12 @@ type Options struct {
 
 	// SignCheckMaxImages limits the number of images to look when verifying
 	SignCheckMaxImages int
+
+	// SignCheckIdentity is the account we expect to sign all imges
+	SignCheckIdentity string
+
+	// SignCheckIssuer is the iisuer of the OIDC tokens used to identify the signer
+	SignCheckIssuer string
 }
 
 var DefaultOptions = &Options{
@@ -129,6 +135,8 @@ var DefaultOptions = &Options{
 	SignCheckFix:        false,
 	SignCheckReferences: []string{},
 	SignCheckFromDays:   5,
+	SignCheckIdentity:   "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
+	SignCheckIssuer:     "https://accounts.google.com",
 }
 
 func (o *Options) Validate() error {

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -109,8 +109,8 @@ type Options struct {
 	// SignCheckFix when true, fix missing signatures
 	SignCheckFix bool
 
-	// SignCheckDays number of days back to check for signatrures
-	SignCheckDays int
+	// SignCheckFromDays number of days back to check for signatrures
+	SignCheckFromDays int
 }
 
 var DefaultOptions = &Options{
@@ -122,7 +122,7 @@ var DefaultOptions = &Options{
 	SignerAccount:       "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
 	SignCheckFix:        false,
 	SignCheckReferences: []string{},
-	SignCheckDays:       5,
+	SignCheckFromDays:   5,
 }
 
 func (o *Options) Validate() error {

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -111,6 +111,9 @@ type Options struct {
 
 	// SignCheckFromDays number of days back to check for signatrures
 	SignCheckFromDays int
+
+	// SignCheckToDays
+	SignCheckToDays int
 }
 
 var DefaultOptions = &Options{

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -112,8 +112,11 @@ type Options struct {
 	// SignCheckFromDays number of days back to check for signatrures
 	SignCheckFromDays int
 
-	// SignCheckToDays
+	// SignCheckToDays complements SignCheckFromDays to enable date ranges
 	SignCheckToDays int
+
+	// SignCheckMaxImages limits the number of images to look when verifying
+	SignCheckMaxImages int
 }
 
 var DefaultOptions = &Options{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:

This PR improves the promoter's signature check code to open the image signatures and look for the expected identity. When verifying signatures, kpromo will now open the signature layer and inspect the certificate, matching it against the expected identity. 

The default identity is the kubernetes signer service account (`krel-trust@k8s-releng-prod.iam.gserviceaccount.com`) and the expected OIDC identity issuer is `https://accounts.google.com`. These can however be modified by defining two new flags: `--certificate-identity` and `--certificate-oidc-issuer`. 

The PR also introduces two quality of life features: The capability to specify date ranges of images to chack and limit the number of images to verify. Here's what the sigcheck subcommand help looks like now:

```
kpromo sigcheck --help


sigcheck - Check signature consistency across the K8s mirrors
    
This subcommand checks the signature consistency across promoted images
to ensure copies in all mirrors have their signatures attached.

By default, kpromo sigcheck will look at all images promoted during the last
 days. You can change the default using --from-days and determine a range
using --to-days. For example, to verify all images promoted in an interval
between 10 and 5 days ago run:

   kpromo sigcheck --from-days=10 --to-days=5

To debug the signature checker, you can limit the number of images kpromo
verifies using --limit. When no limit is specified, kpromo will check the
signatures of all images in the specified date range. As an example, to limit
kpromo to the first three images it finds run:

   kpromo sigcheck --limit=3

```

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

:point_right:  Here are some tests that can be done using this branch:

To check an unsigned image:  

`kpromo sigcheck registry.k8s.io/kube-controller-manager:v1.25.7`

To check a signed image:

`kpromo sigcheck  registry.k8s.io/conformance:v1.23.17`

To check an image signed with the wrong identity:

`kpromo sigcheck --log-level=debug k8s.gcr.io/kube-apiserver:v1.26.0-alpha.3`

/cc @cpanato

#### Does this PR introduce a user-facing change?



```release-note
- `kpromo sigcheck` now checks the certificate of the signatures and compares it against an expected identity. If an image is signed by a different service account or user, the promoter will now detect it. Both the expected identity and OIDC issuer default to the Kubernetes signer service account and they can be overridden using `--certificate-identity` and `--certificate-oidc-issuer`. 
- `kpromo sigcheck` can now act on ranges of days by specifying `--from-days=n --to-days=m` still defaults to checking all images from 5 days ago to today. For debugging purposes, the number of checked images can now be limited used --limit .
```
