### PR TITLE
cip: Expose signing concurrency as flags, default to 50

### DIFF
--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -212,6 +212,20 @@ network from a registry, it reads from the local manifests only`,
 		"when true, sign promoted images",
 	)
 
+	CipCmd.PersistentFlags().IntVar(
+		&runOpts.MaxSignatureCopies,
+		"max-signature-copies",
+		options.DefaultOptions.MaxSignatureCopies,
+		"maximum number of concurrent signature copies",
+	)
+
+	CipCmd.PersistentFlags().IntVar(
+		&runOpts.MaxSignatureOps,
+		"max-signature-ops",
+		options.DefaultOptions.MaxSignatureOps,
+		"maximum number of concurrent signature operations",
+	)
+
 	// TODO: Set this in a function instead
 	if runOpts.MaxImageSize <= 0 {
 		runOpts.MaxImageSize = 2048

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -123,6 +123,12 @@ type Options struct {
 
 	// SignCheckIssuer is the iisuer of the OIDC tokens used to identify the signer
 	SignCheckIssuer string
+
+	// MaxSignatureCopies maximum number of concurrent signature copies
+	MaxSignatureCopies int
+
+	// MaxSignatureOps maximum number of concurrent signature operations
+	MaxSignatureOps int
 }
 
 var DefaultOptions = &Options{
@@ -137,6 +143,8 @@ var DefaultOptions = &Options{
 	SignCheckFromDays:   5,
 	SignCheckIdentity:   "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
 	SignCheckIssuer:     "https://accounts.google.com",
+	MaxSignatureCopies:  50, // Maximum number of concurrent signature copies
+	MaxSignatureOps:     50, // Maximum number of concurrent signature operations
 }
 
 func (o *Options) Validate() error {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR exposes the concurrency limits for signing and replicating operations. The goal is to be able to control these limits via the promoter job configuration instead of having to cut a new release to change the concurrency limits.

```
  --max-signature-copies int           maximum number of concurrent signature copies (default 50)
  --max-signature-ops int              maximum number of concurrent signature operations (default 50)
 
```

This PR also lowers the default limits from 100 to 50 to make the burst of hits to the registry smaller when signing.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2962

#### Special notes for your reviewer:

/cc @palnabarun @xmudrii @jeremyrickard @cpanato 

For more context on this issue, please see [this slack thread](https://kubernetes.slack.com/archives/CJH2GBF7Y/p1678895816204009?thread_ts=1678861049.737169&cid=CJH2GBF7Y).

#### Does this PR introduce a user-facing change?
```release-note
`kpromo cip` has new command line flags to control concurrency: `--max-signature-copies` and `--max-signature-ops`. The maximum default concurrency for both is now 50 instead of the previously hardcoded 100
```
