### PR TITLE
Rate limit crane.Copy() operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/oauth2 v0.6.0
+	golang.org/x/time v0.2.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 	google.golang.org/api v0.112.0
 	google.golang.org/genproto v0.0.0-20230303212802-e74f57abe488
@@ -281,7 +282,6 @@ require (
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
-	golang.org/x/time v0.2.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/grpc v1.53.0 // indirect

--- a/internal/legacy/dockerregistry/inventory.go
+++ b/internal/legacy/dockerregistry/inventory.go
@@ -51,7 +51,7 @@ import (
 var rtripper *ratelimit.RoundTripper
 
 func init() {
-	rtripper = ratelimit.NewRoundTripper(83)
+	rtripper = ratelimit.NewRoundTripper(ratelimit.MaxEvents)
 }
 
 // MakeSyncContext creates a SyncContext.

--- a/internal/legacy/dockerregistry/inventory.go
+++ b/internal/legacy/dockerregistry/inventory.go
@@ -44,8 +44,15 @@ import (
 	cipJson "sigs.k8s.io/promo-tools/v3/internal/legacy/json"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/reqcounter"
 	"sigs.k8s.io/promo-tools/v3/internal/legacy/stream"
+	"sigs.k8s.io/promo-tools/v3/promoter/image/ratelimit"
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
+
+var rtripper *ratelimit.RoundTripper
+
+func init() {
+	rtripper = ratelimit.NewRoundTripper(83)
+}
 
 // MakeSyncContext creates a SyncContext.
 func MakeSyncContext(
@@ -1752,6 +1759,7 @@ func (sc *SyncContext) Promote(
 					opts := []crane.Option{
 						crane.WithAuthFromKeychain(gcrane.Keychain),
 						crane.WithUserAgent(image.UserAgent),
+						crane.WithTransport(rtripper),
 					}
 					if err := crane.Copy(srcVertex, dstVertex, opts...); err != nil {
 						logrus.Error(err)

--- a/internal/legacy/dockerregistry/inventory.go
+++ b/internal/legacy/dockerregistry/inventory.go
@@ -48,12 +48,6 @@ import (
 	"sigs.k8s.io/promo-tools/v3/types/image"
 )
 
-var rtripper *ratelimit.RoundTripper
-
-func init() {
-	rtripper = ratelimit.NewRoundTripper(ratelimit.MaxEvents)
-}
-
 // MakeSyncContext creates a SyncContext.
 func MakeSyncContext(
 	mfests []schema.Manifest,
@@ -1759,7 +1753,7 @@ func (sc *SyncContext) Promote(
 					opts := []crane.Option{
 						crane.WithAuthFromKeychain(gcrane.Keychain),
 						crane.WithUserAgent(image.UserAgent),
-						crane.WithTransport(rtripper),
+						crane.WithTransport(ratelimit.Limiter),
 					}
 					if err := crane.Copy(srcVertex, dstVertex, opts...); err != nil {
 						logrus.Error(err)

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -45,12 +45,6 @@ const (
 	signatureTagSuffix = ".sig"
 
 	TestSigningAccount = "k8s-infra-promoter-test-signer@k8s-cip-test-prod.iam.gserviceaccount.com"
-
-	// Number of events to pass to the crane rate limiter to match the
-	// AR api limits:
-	// https://github.com/kubernetes/registry.k8s.io/issues/153#issuecomment-1460913153
-	// bentheelder: (83*60=4980)
-	rateLimitEvents = 83
 )
 
 // ValidateStagingSignatures checks if edges (images) have a signature
@@ -103,7 +97,7 @@ func (di *DefaultPromoterImplementation) CopySignatures(
 ) error {
 	// Cycle all signedEdges to copy them
 	logrus.Infof("Precopying %d previous signatures", len(signedEdges))
-	rtripper := ratelimit.NewRoundTripper(rateLimitEvents)
+	rtripper := ratelimit.NewRoundTripper(ratelimit.MaxEvents)
 	t := throttler.New(opts.MaxSignatureCopies, len(signedEdges))
 	for e := range signedEdges {
 		go func(edge reg.PromotionEdge) {
@@ -293,7 +287,7 @@ func (di *DefaultPromoterImplementation) replicateSignatures(
 		}{ref, dsts[i].DstRegistry.Token})
 	}
 
-	rtripper := ratelimit.NewRoundTripper(rateLimitEvents)
+	rtripper := ratelimit.NewRoundTripper(ratelimit.MaxEvents)
 
 	// Copy the signatures to the missing registries
 	for _, dstRef := range dstRefs {

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ratelimit
+
+import (
+	"context"
+	"net/http"
+
+	"golang.org/x/time/rate"
+)
+
+const burst = 1
+
+// RoundTripper wraps an http.RoundTripper with rate limiting
+type RoundTripper struct {
+	rateLimiter  *rate.Limiter
+	roundTripper http.RoundTripper
+}
+
+var _ http.RoundTripper = &RoundTripper{}
+
+func NewRoundTripper(limit rate.Limit) *RoundTripper {
+	return &RoundTripper{
+		rateLimiter:  rate.NewLimiter(limit, burst),
+		roundTripper: http.DefaultTransport,
+	}
+}
+
+func (rt *RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	// only rate limit read type calls, not writes
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		err := rt.rateLimiter.Wait(context.Background())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return rt.roundTripper.RoundTrip(r)
+}

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -23,7 +23,15 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const burst = 1
+const (
+	burst = 1
+
+	// Number of events to pass to the crane rate limiter to match the
+	// AR api limits:
+	// https://github.com/kubernetes/registry.k8s.io/issues/153#issuecomment-1460913153
+	// bentheelder: (83*60=4980)
+	MaxEvents = 83
+)
 
 // RoundTripper wraps an http.RoundTripper with rate limiting
 type RoundTripper struct {

--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -41,6 +41,14 @@ type RoundTripper struct {
 
 var _ http.RoundTripper = &RoundTripper{}
 
+var Limiter *RoundTripper
+
+func init() {
+	if Limiter == nil {
+		Limiter = NewRoundTripper(MaxEvents)
+	}
+}
+
 func NewRoundTripper(limit rate.Limit) *RoundTripper {
 	return &RoundTripper{
 		rateLimiter:  rate.NewLimiter(limit, burst),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a new `ratelimiter` packaged based on [geranos' roundtripper](https://github.com/kubernetes/registry.k8s.io/blob/main/cmd/geranos/ratelimitroundtrip.go).

Based on it, we now rate limit the crane operations in the signature package to ensure
they are under the [AR quotas set up by k8s infra](https://github.com/kubernetes/registry.k8s.io/issues/153#issuecomment-1460913153).

Update: I've added the rate limit to the image promotion copy operations too.

(Thanks @BenTheElder ! )

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2962

#### Special notes for your reviewer:

/cc @BenTheElder @xmudrii @palnabarun @ameukam 

More context in [this slack thread](https://kubernetes.slack.com/archives/CJH2GBF7Y/p1678895816204009?thread_ts=1678861049.737169&cid=CJH2GBF7Y)

#### Does this PR introduce a user-facing change?

```release-note
Concurrent copy operations are now rate limited when promoting and replicating and mirroring signatures using a new `ratelimiter` package based on the [geranos rate limiter](https://github.com/kubernetes/registry.k8s.io/blob/main/cmd/geranos/ratelimitroundtrip.go) (Thanks @BenTheElder )
```
