### PR TITLE
inventory: Don't copy manifests to avoid allocation, bump ggcr

### DIFF
--- a/internal/legacy/dockerregistry/inventory.go
+++ b/internal/legacy/dockerregistry/inventory.go
@@ -1095,9 +1095,9 @@ func (sc *SyncContext) ReadGCRManifestLists(
 			//nolint:errcheck
 			gmlc := req.RequestParams.(GCRManifestListContext)
 
-			for _, gManifest := range gcrManifestList.Manifests {
+			for i := range gcrManifestList.Manifests {
 				mutex.Lock()
-				sc.ParentDigest[image.Digest((gManifest.Digest.Algorithm)+":"+(gManifest.Digest.Hex))] = gmlc.Digest
+				sc.ParentDigest[image.Digest((gcrManifestList.Manifests[i].Digest.Algorithm)+":"+(gcrManifestList.Manifests[i].Digest.Hex))] = gmlc.Digest
 				mutex.Unlock()
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR modifies a loop in `inventory.go` to avoid an allocation that was causing the golangci linter to reject the upgrade to GGCR 0.14.


#### Which issue(s) this PR fixes:

Supersedes https://github.com/kubernetes-sigs/promo-tools/pull/777

#### Special notes for your reviewer:

/cc @cpanato 

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
