### PR TITLE
Change signature annotation to version

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/promo-tools/v3/promoter/image/ratelimit"
 	"sigs.k8s.io/promo-tools/v3/types/image"
 	"sigs.k8s.io/release-sdk/sign"
+	"sigs.k8s.io/release-utils/version"
 )
 
 const (
@@ -210,20 +211,10 @@ func (di *DefaultPromoterImplementation) signAndReplicate(signOpts *sign.Options
 	// Build the reference we will use
 	imageRef := edges[0].DstReference()
 
-	// Add all the references as annotations to ensure we
-	// get a 2nd signature, otherwise cosign will not resign
-	mirrorList := []string{}
-	for i := range edges {
-		mirrorList = append(
-			mirrorList, fmt.Sprintf(
-				"%s/%s",
-				edges[i].DstRegistry.Name,
-				edges[i].DstImageTag.Name,
-			),
-		)
-	}
+	// Add an annotation recording the kpromo version to ensure we
+	// get a 2nd signature, otherwise cosign will not resign a signed image:
 	signOpts.Annotations = map[string]interface{}{
-		"org.kubernetes.kpromo.mirrors": strings.Join(mirrorList, ","),
+		"org.kubernetes.kpromo.version": fmt.Sprintf("kpromo-%s", version.GetVersionInfo().GitVersion),
 	}
 
 	logrus.Infof("Signing image %s", imageRef)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Before this commit, we used to annotate the image signatures with a record of the mirrors where we promoted the images. We need an annotation in order to force cosign to add a signature to images which are already promoted.

But now we are promoting to dozens of registries and it has made the original annotation cumbersome and bloated.

This PR changes the annotation to record the promoter version instead.



#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/assign @xmudrii @jeremyrickard 

#### Does this PR introduce a user-facing change?


```release-note
`kpromo` no longer annotates the image signatures with the mirrors it used as the list is now too large to be useful. As we still need an annotation, it will add an annotation with its own version:
    `"org.kubernetes.kpromo.version": "kpromo-v3.5.1"`
```
