### PR TITLE
Use throttler for HTTP calls

### DIFF
--- a/internal/legacy/stream/http.go
+++ b/internal/legacy/stream/http.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/promo-tools/v3/promoter/image/ratelimit"
 )
 
 // HTTP is a wrapper around the net/http's Request type.
@@ -40,7 +41,8 @@ const (
 // stderr). In this case we equate the http.Respose "Body" with stdout.
 func (h *HTTP) Produce() (stdOut, stdErr io.Reader, err error) {
 	client := http.Client{
-		Timeout: time.Second * requestTimeoutSeconds,
+		Transport: ratelimit.Limiter,
+		Timeout:   time.Second * requestTimeoutSeconds,
 	}
 
 	// TODO: Does Close() need to be handled in a separate method?


### PR DESCRIPTION
These weren't subject to throttling, so may contribute to quota issues.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Use the throttler for some HTTP requests in the promoter that were missed.

#### Which issue(s) this PR fixes:

None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

/cc @puerco 
