### PR TITLE
Replicate signatures just once

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -223,6 +223,12 @@ func (di *DefaultPromoterImplementation) copyAttachedObjects(edge *reg.Promotion
 	}
 
 	if err := crane.Copy(srcRef.String(), dstRef.String(), craneOpts...); err != nil {
+		// If the signature layer does not exist it means that the src image
+		// is not signed, so we catch the error and return nil
+		if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+			logrus.Debugf("Reference %s is not signed, not copying", srcRef.String())
+			return nil
+		}
 		return fmt.Errorf(
 			"copying signature %s to %s: %w", srcRef.String(), dstRef.String(), err,
 		)

--- a/promoter/image/imagefakes/fake_promoter_implementation.go
+++ b/promoter/image/imagefakes/fake_promoter_implementation.go
@@ -53,19 +53,6 @@ type FakePromoterImplementation struct {
 		result1 []schema.Manifest
 		result2 error
 	}
-	CopySignaturesStub        func(*imagepromotera.Options, *inventory.SyncContext, map[inventory.PromotionEdge]interface{}) error
-	copySignaturesMutex       sync.RWMutex
-	copySignaturesArgsForCall []struct {
-		arg1 *imagepromotera.Options
-		arg2 *inventory.SyncContext
-		arg3 map[inventory.PromotionEdge]interface{}
-	}
-	copySignaturesReturns struct {
-		result1 error
-	}
-	copySignaturesReturnsOnCall map[int]struct {
-		result1 error
-	}
 	FixMissingSignaturesStub        func(*imagepromotera.Options, checkresults.Signature) error
 	fixMissingSignaturesMutex       sync.RWMutex
 	fixMissingSignaturesArgsForCall []struct {
@@ -454,69 +441,6 @@ func (fake *FakePromoterImplementation) AppendManifestToSnapshotReturnsOnCall(i 
 		result1 []schema.Manifest
 		result2 error
 	}{result1, result2}
-}
-
-func (fake *FakePromoterImplementation) CopySignatures(arg1 *imagepromotera.Options, arg2 *inventory.SyncContext, arg3 map[inventory.PromotionEdge]interface{}) error {
-	fake.copySignaturesMutex.Lock()
-	ret, specificReturn := fake.copySignaturesReturnsOnCall[len(fake.copySignaturesArgsForCall)]
-	fake.copySignaturesArgsForCall = append(fake.copySignaturesArgsForCall, struct {
-		arg1 *imagepromotera.Options
-		arg2 *inventory.SyncContext
-		arg3 map[inventory.PromotionEdge]interface{}
-	}{arg1, arg2, arg3})
-	stub := fake.CopySignaturesStub
-	fakeReturns := fake.copySignaturesReturns
-	fake.recordInvocation("CopySignatures", []interface{}{arg1, arg2, arg3})
-	fake.copySignaturesMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakePromoterImplementation) CopySignaturesCallCount() int {
-	fake.copySignaturesMutex.RLock()
-	defer fake.copySignaturesMutex.RUnlock()
-	return len(fake.copySignaturesArgsForCall)
-}
-
-func (fake *FakePromoterImplementation) CopySignaturesCalls(stub func(*imagepromotera.Options, *inventory.SyncContext, map[inventory.PromotionEdge]interface{}) error) {
-	fake.copySignaturesMutex.Lock()
-	defer fake.copySignaturesMutex.Unlock()
-	fake.CopySignaturesStub = stub
-}
-
-func (fake *FakePromoterImplementation) CopySignaturesArgsForCall(i int) (*imagepromotera.Options, *inventory.SyncContext, map[inventory.PromotionEdge]interface{}) {
-	fake.copySignaturesMutex.RLock()
-	defer fake.copySignaturesMutex.RUnlock()
-	argsForCall := fake.copySignaturesArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *FakePromoterImplementation) CopySignaturesReturns(result1 error) {
-	fake.copySignaturesMutex.Lock()
-	defer fake.copySignaturesMutex.Unlock()
-	fake.CopySignaturesStub = nil
-	fake.copySignaturesReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakePromoterImplementation) CopySignaturesReturnsOnCall(i int, result1 error) {
-	fake.copySignaturesMutex.Lock()
-	defer fake.copySignaturesMutex.Unlock()
-	fake.CopySignaturesStub = nil
-	if fake.copySignaturesReturnsOnCall == nil {
-		fake.copySignaturesReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.copySignaturesReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakePromoterImplementation) FixMissingSignatures(arg1 *imagepromotera.Options, arg2 checkresults.Signature) error {
@@ -1825,8 +1749,6 @@ func (fake *FakePromoterImplementation) Invocations() map[string][][]interface{}
 	defer fake.activateServiceAccountsMutex.RUnlock()
 	fake.appendManifestToSnapshotMutex.RLock()
 	defer fake.appendManifestToSnapshotMutex.RUnlock()
-	fake.copySignaturesMutex.RLock()
-	defer fake.copySignaturesMutex.RUnlock()
 	fake.fixMissingSignaturesMutex.RLock()
 	defer fake.fixMissingSignaturesMutex.RUnlock()
 	fake.fixPartialSignaturesMutex.RLock()

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -100,14 +100,6 @@ func TestPromoteImages(t *testing.T) {
 			},
 		},
 		{
-			// CopySignatures fails
-			shouldErr: true,
-			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
-				fpi.MakeSyncContextReturns(&reg.SyncContext{UseServiceAccount: true}, nil)
-				fpi.CopySignaturesReturns(testErr)
-			},
-		},
-		{
 			// SignImages fails
 			shouldErr: true,
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This commit modifies the promoter to only copy signatures from the staging registries once. Before this change, we would copy any existing signatures to all registries and then rewrite them once the image was re-signed by the image promoter. This was legacy code from a previous attempt to attach new signatures to existing ones.

This change should speed up the promoter and drop the number of calls to the backing registries helping with the rate limit.

#### Which issue(s) this PR fixes:

Part of: https://github.com/kubernetes/release/issues/2962
Fixes: https://github.com/kubernetes-sigs/promo-tools/issues/784

#### Special notes for your reviewer:

/assign @xmudrii @saschagrunert @Verolop @jeremyrickard 

#### Does this PR introduce a user-facing change?

```release-note
`kpromo` will now copy any signatures from the staging registries only once, sign them and then replicate. Before, we copied signatures to all mirrors before signing.
```
