### PR TITLE
Rate limiter: Drop QPS to 50

### DIFF
--- a/promoter/image/ratelimit/roundtripper.go
+++ b/promoter/image/ratelimit/roundtripper.go
@@ -30,7 +30,9 @@ const (
 	// AR api limits:
 	// https://github.com/kubernetes/registry.k8s.io/issues/153#issuecomment-1460913153
 	// bentheelder: (83*60=4980)
-	MaxEvents = 83
+	// Temp: We are temporarily dropping this from the max of 83 to
+	// two thirds while the rate limiter is instrumented everywhere.
+	MaxEvents = 50
 )
 
 // RoundTripper wraps an http.RoundTripper with rate limiting


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This commit drops the rate limiter to 50 to lower the pressure on the API calls to AR

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2962

#### Special notes for your reviewer:

/assign @xmudrii 

#### Does this PR introduce a user-facing change?
```release-note
kpromo will now limit the concurrent calls to the registry to 50 qps  where the rate limiter is instrumented
```
