### PR TITLE
Fix kpromo version in cloudbuild job

### DIFF
--- a/go_with_version.sh
+++ b/go_with_version.sh
@@ -38,7 +38,7 @@ elif [ "$1" != build ] && [ "$1" != install ] && [ "$1" != run ]; then
     exit 1
 fi
 
-tool="$2"
+tool="$1"
 git_tree_state=dirty
 pkg=sigs.k8s.io/promo-tools/internal/version
 


### PR DESCRIPTION


#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
git files are exuded by default in Google Cloud build, which means that we have no kpromo `GitVersion`/`GitCommit`available in:

```
> podman run -it registry.k8s.io/artifact-promoter/kpromo:v3.5.2-0 version
  _  __  ____    ____     ___    __  __    ___
 | |/ / |  _ \  |  _ \   / _ \  |  \/  |  / _ \
 | ' /  | |_) | | |_) | | | | | | |\/| | | | | |
 | . \  |  __/  |  _ <  | |_| | | |  | | | |_| |
 |_|\_\ |_|     |_| \_\  \___/  |_|  |_|  \___/
kpromo: Kubernetes project artifact promoter

GitVersion:
GitCommit:
GitTreeState:  clean
BuildDate:     2023-04-05T20:43:02Z
GoVersion:     go1.19.8
Compiler:      gc
Platform:      linux/amd64
```

Means we also have this information not available in the signatures:

```
> cosign verify \
    --certificate-identity krel-trust@k8s-releng-prod.iam.gserviceaccount.com \
    --certificate-oidc-issuer https://accounts.google.com \
    registry.k8s.io/security-profiles-operator/security-profiles-operator:v0.8.0 | jq '.[0].optional."org.kubernetes.kpromo.version"'
…
"kpromo-"
```

This is now fixed by using an empty `.gcloudignore` file.

This commit also fixes to print the correct build step in the `go_with_version` script.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed missing kpromo version in container images.
```
