### PR TITLE
Use recursive signing for multi-arch images

### DIFF
--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -114,6 +114,9 @@ func (di *DefaultPromoterImplementation) SignImages(
 	}
 	signOpts.IdentityToken = token
 
+	// We want to sign all entities for multi-arch images
+	signOpts.Recursive = true
+
 	// Creating a new Signer after setting the identity token is MANDATORY
 	// because that's the only way to propagate the identity token to the
 	// internal Signer structs. Without that, the identity token wouldn't be

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -337,6 +337,10 @@ func (di *DefaultPromoterImplementation) signReference(opts *options.Options, re
 		return fmt.Errorf("generating identity token: %w", err)
 	}
 	signOpts.IdentityToken = token
+
+	// We want to sign all entities for multi-arch images
+	signOpts.Recursive = true
+
 	di.signer = sign.New(signOpts)
 
 	// Add an annotation recording the kpromo version to ensure we


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Update the release-sdk and set the option to `true`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
PTAL @kubernetes-sigs/release-engineering 

We would require a new kpromo release for this.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Use recursive signing for multi-arch images.
```
