### PR TITLE
Link kpromo statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,16 @@ endif
 
 PKG=sigs.k8s.io/release-utils/version
 LDFLAGS='"-X $(PKG).gitVersion=$(GIT_VERSION) -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)"'
+export CGO_ENABLED=1
 
 .PHONY: kpromo
 kpromo:
-	${REPO_ROOT}/go_with_version.sh build -trimpath -ldflags '-s -w -buildid= -extldflags "-static" $(LDFLAGS)' -o ./bin/kpromo ./cmd/kpromo
+	go build \
+		-trimpath \
+		-ldflags '-s -w -buildid= -linkmode=external -extldflags=-static $(LDFLAGS)' \
+		-tags osusergo \
+		-o ./bin/kpromo \
+		./cmd/kpromo
 
 .PHONY: cip-mm
 cip-mm: kpromo


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We have to choose the `-linkmode=external` to let statically linking work. Beside that, we now omit using the build script and invoke `go build` directly.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
