### PR TITLE
Increase recursive signing timeout

### DIFF
--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -19,6 +19,7 @@ package imagepromoter
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -54,8 +55,21 @@ type DefaultPromoterImplementation struct {
 // NewDefaultPromoterImplementation creates a new DefaultPromoterImplementation instance.
 func NewDefaultPromoterImplementation() *DefaultPromoterImplementation {
 	return &DefaultPromoterImplementation{
-		signer: sign.New(sign.Default()),
+		signer: sign.New(defaultSignerOptions()),
 	}
+}
+
+// defaultSignerOptions returns a new *sign.Options with default values applied.
+func defaultSignerOptions() *sign.Options {
+	opts := sign.Default()
+
+	// We want to sign all entities for multi-arch images
+	opts.Recursive = true
+
+	// Recursive signing can take a bit longer than usual
+	opts.Timeout = 15 * time.Minute
+
+	return opts
 }
 
 // ValidateOptions checks an options set

--- a/internal/promoter/image/sign.go
+++ b/internal/promoter/image/sign.go
@@ -105,7 +105,7 @@ func (di *DefaultPromoterImplementation) SignImages(
 	}
 
 	// Options for the new signer
-	signOpts := sign.Default()
+	signOpts := defaultSignerOptions()
 
 	// Get the identity token we will use
 	token, err := di.GetIdentityToken(opts, opts.SignerAccount)
@@ -113,9 +113,6 @@ func (di *DefaultPromoterImplementation) SignImages(
 		return fmt.Errorf("generating identity token: %w", err)
 	}
 	signOpts.IdentityToken = token
-
-	// We want to sign all entities for multi-arch images
-	signOpts.Recursive = true
 
 	// Creating a new Signer after setting the identity token is MANDATORY
 	// because that's the only way to propagate the identity token to the

--- a/internal/promoter/image/signcheck.go
+++ b/internal/promoter/image/signcheck.go
@@ -329,7 +329,7 @@ func (di *DefaultPromoterImplementation) signReference(opts *options.Options, re
 	logrus.Infof(" signing %s", refString)
 
 	// Options for the new signer
-	signOpts := sign.Default()
+	signOpts := defaultSignerOptions()
 
 	// Get the identity token we will use
 	token, err := di.GetIdentityToken(opts, opts.SignerAccount)
@@ -337,9 +337,6 @@ func (di *DefaultPromoterImplementation) signReference(opts *options.Options, re
 		return fmt.Errorf("generating identity token: %w", err)
 	}
 	signOpts.IdentityToken = token
-
-	// We want to sign all entities for multi-arch images
-	signOpts.Recursive = true
 
 	di.signer = sign.New(signOpts)
 


### PR DESCRIPTION


#### What type of PR is this?

/kind flake


#### What this PR does / why we need it:
The root timeout defaults to 3 minutes, which can be too short for recursive signing. Means we now increase the timeout to 15 minutes to deflake the CI.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes-sigs/promo-tools/issues/892
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Increased sign timeout to 15 minutes to deflake recursive signing.
```
