### PR TITLE
add SignCheckIdentityRegexp and SignCheckIssuerRegexp options

### DIFF
--- a/cmd/kpromo/cmd/cip/cip.go
+++ b/cmd/kpromo/cmd/cip/cip.go
@@ -209,6 +209,20 @@ network from a registry, it reads from the local manifests only`,
 		"OIDC Issuer that will be used for the signing identity, used for verify the images",
 	)
 
+	CipCmd.PersistentFlags().StringVar(
+		&runOpts.SignCheckIdentityRegexp,
+		"certificate-identity-regexp",
+		"",
+		"A regular expression alternative to --certificate-identity. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.",
+	)
+
+	CipCmd.PersistentFlags().StringVar(
+		&runOpts.SignCheckIssuerRegexp,
+		"certificate-oidc-issuer-regexp",
+		"",
+		"A regular expression alternative to --certificate-oidc-issuer. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax.",
+	)
+
 	CipCmd.PersistentFlags().BoolVar(
 		&runOpts.SignImages,
 		"sign",

--- a/cmd/kpromo/cmd/sigcheck/sigcheck.go
+++ b/cmd/kpromo/cmd/sigcheck/sigcheck.go
@@ -101,5 +101,19 @@ kpromo to the first three images it finds run:
 		"issuer of the OIDC token used to generate the signature certificate",
 	)
 
+	cmd.PersistentFlags().StringVar(
+		&opts.SignCheckIdentityRegexp,
+		"certificate-identity-regexp",
+		"",
+		"A regular expression alternative to --certificate-identity. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&opts.SignCheckIssuerRegexp,
+		"certificate-oidc-issuer-regexp",
+		"",
+		"A regular expression alternative to --certificate-oidc-issuer. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax.",
+	)
+
 	parent.AddCommand(cmd)
 }

--- a/internal/promoter/image/impl.go
+++ b/internal/promoter/image/impl.go
@@ -69,16 +69,17 @@ func defaultSignerOptions(opts *options.Options) *sign.Options {
 	// Recursive signing can take a bit longer than usual
 	signOpts.Timeout = 15 * time.Minute
 
-	// The Certificate Identity to be used to checck the images signatures
+	// The Certificate Identity to be used to check the images signatures
 	signOpts.CertIdentity = opts.SignCheckIdentity
 
-	// The Certificate OICD Issuer to be used to checck the images signatures
+	// The Certificate OICD Issuer to be used to check the images signatures
 	signOpts.CertOidcIssuer = opts.SignCheckIssuer
 
-	// Not used right now but set to empty in the library those have a definition
-	// and we don't want those here.
-	signOpts.CertIdentityRegexp = ""
-	signOpts.CertOidcIssuerRegexp = ""
+	// A regex Certificate Identity to be used to check the images signatures
+	signOpts.CertIdentityRegexp = opts.SignCheckIdentityRegexp
+
+	// A regex to match a Certificate OICD Issuer to be used to check the images signatures
+	signOpts.CertOidcIssuerRegexp = opts.SignCheckIssuerRegexp
 
 	return signOpts
 }

--- a/promoter/image/options/options.go
+++ b/promoter/image/options/options.go
@@ -107,11 +107,17 @@ type Options struct {
 	// SignCheckMaxImages limits the number of images to look when verifying
 	SignCheckMaxImages int
 
-	// SignCheckIdentity is the account we expect to sign all imges
+	// SignCheckIdentity is the account we expect to sign all images
 	SignCheckIdentity string
 
-	// SignCheckIssuer is the iisuer of the OIDC tokens used to identify the signer
+	// SignCheckIssuer is the issuer of the OIDC tokens used to identify the signer
 	SignCheckIssuer string
+
+	// SignCheckIdentityRegexp can use a regex to match more than one signer
+	SignCheckIdentityRegexp string
+
+	// SignCheckIssuerRegexp can use a regex to match more than one signer OIDC tokens used to identify the signer
+	SignCheckIssuerRegexp string
 
 	// MaxSignatureCopies maximum number of concurrent signature copies
 	MaxSignatureCopies int
@@ -121,18 +127,20 @@ type Options struct {
 }
 
 var DefaultOptions = &Options{
-	OutputFormat:        "yaml",
-	Threads:             10,
-	SeverityThreshold:   -1,
-	SignImages:          true,
-	SignerAccount:       "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
-	SignCheckFix:        false,
-	SignCheckReferences: []string{},
-	SignCheckFromDays:   5,
-	SignCheckIdentity:   "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
-	SignCheckIssuer:     "https://accounts.google.com",
-	MaxSignatureCopies:  50, // Maximum number of concurrent signature copies
-	MaxSignatureOps:     50, // Maximum number of concurrent signature operations
+	OutputFormat:            "yaml",
+	Threads:                 10,
+	SeverityThreshold:       -1,
+	SignImages:              true,
+	SignerAccount:           "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
+	SignCheckFix:            false,
+	SignCheckReferences:     []string{},
+	SignCheckFromDays:       5,
+	SignCheckIdentity:       "krel-trust@k8s-releng-prod.iam.gserviceaccount.com",
+	SignCheckIssuer:         "https://accounts.google.com",
+	SignCheckIdentityRegexp: "",
+	SignCheckIssuerRegexp:   "",
+	MaxSignatureCopies:      50, // Maximum number of concurrent signature copies
+	MaxSignatureOps:         50, // Maximum number of concurrent signature operations
 }
 
 func (o *Options) Validate() error {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup
/kind feature


#### What this PR does / why we need it:
- add SignCheckIdentityRegexp and SignCheckIssuerRegexp options
in the canary job we can have multiple certificate Identity and OIDC Issuer so we should be able to add a regex to match multiple Identities. 

see https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-promo-tools-image-promo-canary/1666071894488518656

Will update the canary job to support this as well

/assign @saschagrunert @xmudrii 
cc @kubernetes-sigs/release-engineering 


#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add SignCheckIdentityRegexp and SignCheckIssuerRegexp options
```
