### PR TITLE
kpromo gh: use `--org/--repo` as new default for `--release-dir`

### DIFF
--- a/cmd/kpromo/cmd/gh/gh.go
+++ b/cmd/kpromo/cmd/gh/gh.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -77,7 +78,6 @@ var (
 		orgFlag,
 		repoFlag,
 		bucketFlag,
-		releaseDirFlag,
 	}
 )
 
@@ -121,7 +121,7 @@ func init() {
 		&opts.releaseDir,
 		releaseDirFlag,
 		"",
-		"directory to upload to within the specified GCS bucket",
+		fmt.Sprintf("directory to upload to within the specified GCS bucket, defaults to %q", filepath.Join(orgFlag, repoFlag)),
 	)
 
 	GHCmd.PersistentFlags().StringVar(
@@ -234,6 +234,11 @@ func run(opts *options) error {
 // SetAndValidate sets some default options and verifies if options are valid
 func (o *options) SetAndValidate() error {
 	logrus.Info("Validating gh2gcs options...")
+
+	if o.releaseDir == "" {
+		o.releaseDir = filepath.Join(o.org, o.repo)
+		logrus.Infof("Using default release dir: %s", o.releaseDir)
+	}
 
 	if o.outputDir == "" {
 		if opts.downloadOnly {


### PR DESCRIPTION


#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
We now default `--release-dir` to the org and repo directory file path to simplify upload for buckets which should be used for multiple repositories.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kpromo gh: use `--org/--repo` as new default for `--release-dir`
```
