### PR TITLE
kpromo: set git clone depth for pr subcommand to prevent downloading the whole repository

### DIFF
--- a/cmd/kpromo/cmd/pr/pr.go
+++ b/cmd/kpromo/cmd/pr/pr.go
@@ -207,8 +207,10 @@ func runPromote(opts *promoteOptions) error {
 	}
 
 	// Clone k8s.io
-	// We might want to set options to pass for the clone, nothing for now
-	gitCloneOpts := &gogit.CloneOptions{}
+	gitCloneOpts := &gogit.CloneOptions{
+		// Set a minimal depth to prevent downloading the whole repository.
+		Depth: 1,
+	}
 	repo, err := github.PrepareFork(branchname, git.DefaultGithubOrg, k8sioRepo, userForkOrg, userForkRepo, opts.useSSH, opts.updateRepo, gitCloneOpts)
 	if err != nil {
 		return fmt.Errorf("while preparing k/k8s.io fork: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds git clone options for cloning the `kubernetes/k8s.io` repository to only clone a depth of 1.

The `kubernetes/k8s.io` did grow in the past to a big (1,4GB to download) repository:

```
❯ git clone https://github.com/kubernetes/k8s.io.git
Cloning into 'k8s.io'...
remote: Enumerating objects: 211546, done.
remote: Counting objects: 100% (1397/1397), done.
remote: Compressing objects: 100% (881/881), done.
remote: Total 211546 (delta 428), reused 1294 (delta 359), pack-reused 210149 (from 1)
Receiving objects: 100% (211546/211546), 1.27 GiB | 6.65 MiB/s, done.
Resolving deltas: 100% (122622/122622), done.
Updating files: 100% (15059/15059), done.
❯ du -h -d 0 k8s.io
1.4G    k8s.io
```

This change should reduce the downloaded size from 1.27 GiB to currently ~29.29 MiB instead.

```
❯ git clone --depth 1 https://github.com/kubernetes/k8s.io.git
Cloning into 'k8s.io'...
remote: Enumerating objects: 17520, done.
remote: Counting objects: 100% (17520/17520), done.
remote: Compressing objects: 100% (9760/9760), done.
remote: Total 17520 (delta 8344), reused 14982 (delta 7181), pack-reused 0 (from 0)
Receiving objects: 100% (17520/17520), 29.29 MiB | 4.14 MiB/s, done.
Resolving deltas: 100% (8344/8344), done.
Updating files: 100% (15059/15059), done.
❯ du -h -d 0 k8s.io
142M    k8s.io
```

So this reduces the amount of data which is downloaded when running `kpromo pr ...` and by that also reduce the time for maintainers to run kpromo.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
kpromo pr: Only clone the head commit to reduce amount of data to download
```
