### PR TITLE
Bump golangci-lint to 1.64.8

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # golangci-lint
   - name: "golangci-lint"
-    version: 1.61.0
+    version: 1.64.8
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.61.0
+VERSION=v1.64.8
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 


### PR DESCRIPTION
Fixes some golangci-lint false-positives
