### PR TITLE
chore: refactor containers to use generics

### DIFF
--- a/internal/legacy/container/set.go
+++ b/internal/legacy/container/set.go
@@ -17,14 +17,25 @@ limitations under the License.
 package container
 
 // Set is a basic set-like data structure.
-type Set map[Element]interface{}
+type Set[K comparable] map[K]struct{}
 
-// Element is a singleton item that goes with Set.
-type Element interface{}
+// NewSet contructs a Set with the specified items.
+func NewSet[K comparable](items ...K) Set[K] {
+	s := make(Set[K])
+	for _, item := range items {
+		s[item] = struct{}{}
+	}
+	return s
+}
+
+// Insert inserts an item into the set.
+func (s Set[K]) Insert(item K) {
+	s[item] = struct{}{}
+}
 
 // Minus returns a new set, by subtracting everything in b from a.
-func (a Set) Minus(b Set) Set {
-	c := make(Set)
+func (a Set[K]) Minus(b Set[K]) Set[K] {
+	c := make(Set[K])
 	for k, v := range a {
 		c[k] = v
 	}
@@ -35,8 +46,8 @@ func (a Set) Minus(b Set) Set {
 }
 
 // Union takes two sets and returns their union in a new set.
-func (a Set) Union(b Set) Set {
-	c := make(Set)
+func (a Set[K]) Union(b Set[K]) Set[K] {
+	c := make(Set[K])
 	for k, v := range a {
 		c[k] = v
 	}
@@ -48,8 +59,8 @@ func (a Set) Union(b Set) Set {
 
 // Intersection takes two sets and returns elements common to both. Note that we
 // throw away information about the values of the elements in b.
-func (a Set) Intersection(b Set) Set {
-	c := make(Set)
+func (a Set[K]) Intersection(b Set[K]) Set[K] {
+	c := make(Set[K])
 	for k, v := range a {
 		if _, ok := b[k]; ok {
 			c[k] = v

--- a/internal/legacy/dockerregistry/registry/registry.go
+++ b/internal/legacy/dockerregistry/registry/registry.go
@@ -55,7 +55,11 @@ type DigestTags map[image.Digest]TagSlice
 type TagSlice []image.Tag
 
 // TagSet is a set of Tags.
-type TagSet map[image.Tag]interface{}
+// type TagSet container.Set[image.Tag]
+
+// func NewTagSet(tags ...image.Tag) TagSet {
+// 	return TagSet(container.NewSet(tags...))
+// }
 
 // ToYAML displays a RegInvImage as YAML, but with the map items sorted
 // alphabetically.

--- a/internal/legacy/dockerregistry/registry/set.go
+++ b/internal/legacy/dockerregistry/registry/set.go
@@ -24,59 +24,13 @@ import (
 // Various set manipulation operations. Some set operations are missing,
 // because, we don't use them.
 
-// ToSet converts a RegInvImage to a Set.
-func (a RegInvImage) ToSet() container.Set {
-	b := make(container.Set)
-	for k, v := range a {
-		b[k] = v
-	}
-
-	return b
-}
-
-func toRegistryInventory(a container.Set) RegInvImage {
-	b := make(RegInvImage)
-	for k, v := range a {
-		// TODO: Why are we not checking errors here?
-		//nolint:errcheck
-		b[k.(image.Name)] = v.(DigestTags)
-	}
-
-	return b
-}
-
-// Minus is a set operation.
-// TODO: ST1016: methods on the same type should have the same receiver name.
-func (a RegInvImage) Minus(b RegInvImage) RegInvImage {
-	aSet := a.ToSet()
-	bSet := b.ToSet()
-	cSet := aSet.Minus(bSet)
-
-	return toRegistryInventory(cSet)
-}
-
-// Union is a set operation.
-func (a RegInvImage) Union(b RegInvImage) RegInvImage {
-	aSet := a.ToSet()
-	bSet := b.ToSet()
-	cSet := aSet.Union(bSet)
-
-	return toRegistryInventory(cSet)
-}
-
 // ToTagSet converts a TagSlice to a TagSet.
-func (a TagSlice) ToTagSet() TagSet {
-	b := make(TagSet)
-	for _, t := range a {
-		// The value doesn't matter.
-		b[t] = nil
-	}
-
-	return b
+func (a TagSlice) ToTagSet() container.Set[image.Tag] {
+	return container.NewSet(a...)
 }
 
 // Minus is a set operation.
-func (a TagSlice) Minus(b TagSlice) TagSet {
+func (a TagSlice) Minus(b TagSlice) container.Set[image.Tag] {
 	aSet := a.ToTagSet()
 	bSet := b.ToTagSet()
 	cSet := aSet.Minus(bSet)
@@ -85,7 +39,7 @@ func (a TagSlice) Minus(b TagSlice) TagSet {
 }
 
 // Union is a set operation.
-func (a TagSlice) Union(b TagSlice) TagSet {
+func (a TagSlice) Union(b TagSlice) container.Set[image.Tag] {
 	aSet := a.ToTagSet()
 	bSet := b.ToTagSet()
 	cSet := aSet.Union(bSet)
@@ -94,57 +48,10 @@ func (a TagSlice) Union(b TagSlice) TagSet {
 }
 
 // Intersection is a set operation.
-func (a TagSlice) Intersection(b TagSlice) TagSet {
+func (a TagSlice) Intersection(b TagSlice) container.Set[image.Tag] {
 	aSet := a.ToTagSet()
 	bSet := b.ToTagSet()
 	cSet := aSet.Intersection(bSet)
 
 	return cSet
-}
-
-// ToSet converts a TagSet to a Set.
-func (a TagSet) ToSet() container.Set {
-	b := make(container.Set)
-	for t := range a {
-		// The value doesn't matter.
-		b[t] = nil
-	}
-
-	return b
-}
-
-func setToTagSet(a container.Set) TagSet {
-	b := make(TagSet)
-	for k := range a {
-		b[k.(image.Tag)] = nil
-	}
-
-	return b
-}
-
-// Minus is a set operation.
-func (a TagSet) Minus(b TagSet) TagSet {
-	aSet := a.ToSet()
-	bSet := b.ToSet()
-	cSet := aSet.Minus(bSet)
-
-	return setToTagSet(cSet)
-}
-
-// Union is a set operation.
-func (a TagSet) Union(b TagSet) TagSet {
-	aSet := a.ToSet()
-	bSet := b.ToSet()
-	cSet := aSet.Union(bSet)
-
-	return setToTagSet(cSet)
-}
-
-// Intersection is a set operation.
-func (a TagSet) Intersection(b TagSet) TagSet {
-	aSet := a.ToSet()
-	bSet := b.ToSet()
-	cSet := aSet.Intersection(bSet)
-
-	return setToTagSet(cSet)
 }


### PR DESCRIPTION
golangci-lint was not happy with the type-safety previously.
