### PR TITLE
lint: mark incorrect golangci flag

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -114,7 +114,9 @@ func TestPromoterImageToYAML(t *testing.T) {
 	expectedYAML += "    \"sha256:c752ecbd04bc4517168a19323bb60fb45324eee1e480b2b97d3fd6ea0a54f42d\": [\"v1.18.8\",\"v1.19.0\"]\n"
 
 	yamlCode, err := imageList.ToYAML()
-	require.NoError(t, err, "serilizing imagelist to yaml")
+	require.NoError(t, err, "serializing imagelist to yaml")
+
+	//nolint:testifylint // The whole point of this test is to check the yaml output is stable.
 	require.Equal(t, expectedYAML, string(yamlCode), "checking promoter image list yaml output")
 }
 


### PR DESCRIPTION
The test is checking that the yaml output is stable,
golangci suggestion is wrong.
