### PR TITLE
Fixing build on Macbook ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ export CGO_ENABLED=1
 kpromo:
 	go build \
 		-trimpath \
-		-ldflags '-s -w -buildid= -linkmode=external -extldflags=-static $(LDFLAGS)' \
+		-ldflags '-s -w -buildid= -linkmode=external $(LDFLAGS)' \
 		-tags osusergo \
 		-o ./bin/kpromo \
 		./cmd/kpromo


### PR DESCRIPTION
Fixed the kpromo build for processors with ARM architecture.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixing the build on Macbook ARM.
Unsure if removing static linking is something we want in the long run, tho.
Seeking guidance and a review on this.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Hit me up on the k8s Slack, I'm way more responsive there than on GH PRs.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
