### PR TITLE
Bump golangci-lint to v2.13.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan

--- a/api/files/manifest_test.go
+++ b/api/files/manifest_test.go
@@ -23,6 +23,8 @@ import (
 	"sigs.k8s.io/promo-tools/v4/api/files"
 )
 
+const testFileName = "foo"
+
 func TestValidateFilestores(t *testing.T) {
 	tests := []struct {
 		filestores    []files.Filestore
@@ -104,7 +106,7 @@ func TestValidateFiles(t *testing.T) {
 		},
 		{
 			files: []files.File{
-				{Name: "foo", SHA256: oksha},
+				{Name: testFileName, SHA256: oksha},
 			},
 		},
 		{
@@ -115,19 +117,19 @@ func TestValidateFiles(t *testing.T) {
 		},
 		{
 			files: []files.File{
-				{Name: "foo", SHA256: "bad"},
+				{Name: testFileName, SHA256: "bad"},
 			},
 			expectedError: "sha256 was not valid (not hex)",
 		},
 		{
 			files: []files.File{
-				{Name: "foo"},
+				{Name: testFileName},
 			},
 			expectedError: "sha256 is required",
 		},
 		{
 			files: []files.File{
-				{Name: "foo", SHA256: "abcd"},
+				{Name: testFileName, SHA256: "abcd"},
 			},
 			expectedError: "sha256 was not valid (bad length)",
 		},

--- a/cmd/count-requests/main.go
+++ b/cmd/count-requests/main.go
@@ -142,7 +142,7 @@ func makeRequest(query string) response {
 			panic(reqErr)
 		}
 
-		resp, err = http.DefaultClient.Do(req) //nolint:gosec // URL constructed from trusted config
+		resp, err = http.DefaultClient.Do(req)
 		if err == nil {
 			payload = getPayload(resp)
 		} else if retries == 0 {

--- a/cmd/kpromo/cmd/pr/pr.go
+++ b/cmd/kpromo/cmd/pr/pr.go
@@ -388,8 +388,8 @@ func mustRun(opts *promoteOptions, question string) bool {
 	if err != nil {
 		logrus.Error(err)
 
-		var userInputErr helpers.UserInputError
-		if errors.As(err, &userInputErr) {
+		//nolint:errcheck // only the type match matters, err is already logged
+		if _, ok := errors.AsType[helpers.UserInputError](err); ok {
 			os.Exit(1)
 		}
 

--- a/cmd/verify-gcr-quota/main.go
+++ b/cmd/verify-gcr-quota/main.go
@@ -113,7 +113,7 @@ func worker(c chan message) {
 		return
 	}
 
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL constructed from trusted config
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		fmt.Println("Encountered an error during HTTP GET request: ", err)
 	}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # golangci-lint
   - name: "golangci-lint"
-    version: 2.10.1
+    version: 2.13.1
     refPaths:
     - path: hack/verify-golangci-lint.sh
       match: VERSION=v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v2.10.1
+VERSION=v2.13.1
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=${URL_BASE}/${VERSION}/install.sh
 # If you update the version above you might need to update the checksum
@@ -27,7 +27,7 @@ URL=${URL_BASE}/${VERSION}/install.sh
 # To obtain the checksum, download the install script and run the following
 # command:
 # > sha256sum <path-to-install-script>
-INSTALL_CHECKSUM=edfa587f31bde70db161d1e5b783e086a1627d7e2f7c91de5f7cca79bcdf8631
+INSTALL_CHECKSUM=1022ddb4d87ed252350ed03fc9677e250a4ae95cc6bcd4658c2a20a8a23d390f
 
 if [[ ! -f .golangci.yml ]]; then
     echo 'ERROR: missing .golangci.yml in repo root' >&2

--- a/image/image.go
+++ b/image/image.go
@@ -43,7 +43,7 @@ func NewManifestListFromFile(manifestPath string) (*ManifestList, error) {
 		return nil, errors.New("could not find image promoter manifest")
 	}
 
-	yamlCode, err := os.ReadFile(filepath.Clean(manifestPath)) //nolint:gosec // path already sanitized via filepath.Clean
+	yamlCode, err := os.ReadFile(filepath.Clean(manifestPath))
 	if err != nil {
 		return nil, fmt.Errorf("reading yaml code from file: %w", err)
 	}
@@ -72,7 +72,7 @@ func (imagesList *ManifestList) Write(filePath string) error {
 		return fmt.Errorf("while marshalling image list: %w", err)
 	}
 	// Write the yaml into the specified file
-	if err := os.WriteFile(filepath.Clean(filePath), yamlCode, os.FileMode(0o644)); err != nil { //nolint:gosec // path already sanitized via filepath.Clean
+	if err := os.WriteFile(filepath.Clean(filePath), yamlCode, os.FileMode(0o644)); err != nil {
 		return fmt.Errorf("writing yaml code into file: %w", err)
 	}
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -24,6 +24,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	digest03427 = "sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342"
+	digest594b8 = "sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7"
+	digest37cfe = "sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8"
+	digestAa2e2 = "sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352"
+	tagV210     = "v2.1.0"
+)
+
 func TestNewManifestListFromFile(t *testing.T) {
 	listYAML := "- name: pause\n"
 	listYAML += "  dmap:\n"
@@ -78,7 +86,7 @@ func TestPromoterImageToYAML(t *testing.T) {
 			Name: "hyperkube",
 			DMap: map[string][]string{
 				"sha256:54cdd8d3b74f9c577c8bb4f43e50813f0190006e66efe861bd810ee3f5e7cc7d": {"v1.18.8"},
-				"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342": {"v1.16.16-rc.0"},
+				digest03427: {"v1.16.16-rc.0"},
 				"sha256:9f35b65ee834239ffbbd0ddfb54e0317cf99f10a75d8e8af372af45286d069ab": {"v1.17.10"},
 			},
 		},
@@ -127,8 +135,8 @@ func TestPromoterImageWrite(t *testing.T) {
 		}{
 			Name: "kube-controller-manager-s390x",
 			DMap: map[string][]string{
-				"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7": {"v1.19.1"},
-				"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342": {"v1.19.2"},
+				digest594b8: {"v1.19.1"},
+				digest03427: {"v1.19.2"},
 			},
 		},
 		struct {
@@ -156,7 +164,7 @@ func TestPromoterImageWrite(t *testing.T) {
 	require.NoError(t, err, "writing data to disk")
 
 	// Read back the file to see if it correct
-	fileContents, err := os.ReadFile(tempFileSorted.Name()) //nolint:gosec // test file from os.CreateTemp
+	fileContents, err := os.ReadFile(tempFileSorted.Name())
 	require.NoError(t, err, "reading temporary file")
 
 	require.Equal(t, expectedFile, string(fileContents))
@@ -171,23 +179,23 @@ func Test_sortImageDigestMapByTag(t *testing.T) {
 		{
 			name: "image digests are sorted by tags",
 			dmap: map[string][]string{
-				"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342": {"v1.1.2"},
-				"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7": {"v1.1.1"},
+				digest03427: {"v1.1.2"},
+				digest594b8: {"v1.1.1"},
 			},
 			want: []string{
-				"sha256:594b8333e79ecca96c9ff0cb72a001db181c199d83274ffbe5ccdaedca23bfd7",
-				"sha256:03427dcf5ab5fc5fd3cdfb24170373e8afbed13356270666c823573d7e2a1342",
+				digest594b8,
+				digest03427,
 			},
 		},
 		{
 			name: "multiple tags by image",
 			dmap: map[string][]string{
-				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8": {"v2.1.0", "v2.1.3"},
-				"sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352": {"v2.1.1", "v2.1.2"},
+				digest37cfe: {tagV210, "v2.1.3"},
+				digestAa2e2: {"v2.1.1", "v2.1.2"},
 			},
 			want: []string{
-				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8",
-				"sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352",
+				digest37cfe,
+				digestAa2e2,
 			},
 		},
 		{
@@ -200,11 +208,11 @@ func Test_sortImageDigestMapByTag(t *testing.T) {
 				"sha256:248087165d8f4d901e27a799f10fe4b7b4458469191120385317ad32aa5e3382": {"buster-v1.10.0"},
 				"sha256:2f37650255a457d0fc3a5c685ac1eecb5e0f16c63b58b82e52a585fff0aabff6": {"buster-v1.7.2"},
 				"sha256:36652ef8e4dd6715de02e9b68e5c122ed8ee06c75f83f5c574b97301e794c3fb": {"buster-v1.4.0"},
-				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8": {"buster-v1.1.3", "v2.1.3"},
+				digest37cfe: {"buster-v1.1.3", "v2.1.3"},
 				"sha256:51af4a1e8821f550a5639096f48b88c746118a65832465fc6d22de73cea99985": {"buster-v1.5.0"},
 			},
 			want: []string{
-				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8",
+				digest37cfe,
 				"sha256:248087165d8f4d901e27a799f10fe4b7b4458469191120385317ad32aa5e3382",
 				"sha256:36652ef8e4dd6715de02e9b68e5c122ed8ee06c75f83f5c574b97301e794c3fb",
 				"sha256:51af4a1e8821f550a5639096f48b88c746118a65832465fc6d22de73cea99985",
@@ -218,12 +226,12 @@ func Test_sortImageDigestMapByTag(t *testing.T) {
 		{
 			name: "two images with same tag",
 			dmap: map[string][]string{
-				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8": {"v2.1.0"},
-				"sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352": {"v2.1.0"},
+				digest37cfe: {tagV210},
+				digestAa2e2: {tagV210},
 			},
 			want: []string{
-				"sha256:37cfe133a6ff3fc3aa4aa5ab9fda127861902940b8e8078fff7191c7a81be8d8",
-				"sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352",
+				digest37cfe,
+				digestAa2e2,
 			},
 		},
 	}

--- a/image/manifest/manifest_test.go
+++ b/image/manifest/manifest_test.go
@@ -31,11 +31,23 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
+const (
+	testServiceAccount = "sa@robot.com"
+	imageFoo           = "foo"
+	imageBar           = "bar"
+	tagLatest          = "latest"
+	tag1               = "1.0"
+	tag2               = "2.0"
+	tag3               = "3.0"
+	tag123             = "1.2.3"
+	digest000          = "sha256:000"
+	digest111          = "sha256:111"
+	digest222          = "sha256:222"
+)
+
 func testPath(paths ...string) string {
-	prefix := []string{
-		os.Getenv("PWD"),
-		"testdata",
-	}
+	prefix := make([]string, 0, 2+len(paths))
+	prefix = append(prefix, os.Getenv("PWD"), "testdata")
 
 	return filepath.Join(append(prefix, paths...)...)
 }
@@ -44,7 +56,7 @@ func TestFind(t *testing.T) {
 	pwd := testPath()
 	srcRC := registry.Context{
 		Name:           "gcr.io/foo-staging",
-		ServiceAccount: "sa@robot.com",
+		ServiceAccount: testServiceAccount,
 		Src:            true,
 	}
 
@@ -79,22 +91,22 @@ func TestFind(t *testing.T) {
 					srcRC,
 					{
 						Name:           "us.gcr.io/some-prod",
-						ServiceAccount: "sa@robot.com",
+						ServiceAccount: testServiceAccount,
 					},
 					{
 						Name:           "eu.gcr.io/some-prod",
-						ServiceAccount: "sa@robot.com",
+						ServiceAccount: testServiceAccount,
 					},
 					{
 						Name:           "asia.gcr.io/some-prod",
-						ServiceAccount: "sa@robot.com",
+						ServiceAccount: testServiceAccount,
 					},
 				},
 				Images: []registry.Image{
 					{
 						Name: "foo-controller",
 						Dmap: registry.DigestTags{
-							"sha256:c3d310f4741b3642497da8826e0986db5e02afc9777a2b8e668c8e41034128c1": {"1.0"},
+							"sha256:c3d310f4741b3642497da8826e0986db5e02afc9777a2b8e668c8e41034128c1": {tag1},
 						},
 					},
 				},
@@ -151,13 +163,13 @@ func TestApplyFilters(t *testing.T) {
 			"no filters --- same as input",
 			manifest.GrowOptions{},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"2.0"},
+				imageFoo: {
+					digest000: {tag2},
 				},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"2.0"},
+				imageFoo: {
+					digest000: {tag2},
 				},
 			},
 			nil,
@@ -166,13 +178,13 @@ func TestApplyFilters(t *testing.T) {
 			"remove 'latest' tag by default, even if no filters",
 			manifest.GrowOptions{},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"latest", "2.0"},
+				imageFoo: {
+					digest000: {tagLatest, tag2},
 				},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"2.0"},
+				imageFoo: {
+					digest000: {tag2},
 				},
 			},
 			nil,
@@ -180,19 +192,19 @@ func TestApplyFilters(t *testing.T) {
 		{
 			"filter on image name only",
 			manifest.GrowOptions{
-				FilterImages: []image.Name{"bar"},
+				FilterImages: []image.Name{imageBar},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"latest", "2.0"},
+				imageFoo: {
+					digest000: {tagLatest, tag2},
 				},
-				"bar": {
-					"sha256:111": {"latest", "1.0"},
+				imageBar: {
+					digest111: {tagLatest, tag1},
 				},
 			},
 			registry.RegInvImage{
-				"bar": {
-					"sha256:111": {"1.0"},
+				imageBar: {
+					digest111: {tag1},
 				},
 			},
 			nil,
@@ -200,19 +212,19 @@ func TestApplyFilters(t *testing.T) {
 		{
 			"filter on tag only",
 			manifest.GrowOptions{
-				FilterTags: []image.Tag{"1.0"},
+				FilterTags: []image.Tag{tag1},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"latest", "2.0"},
+				imageFoo: {
+					digest000: {tagLatest, tag2},
 				},
-				"bar": {
-					"sha256:111": {"latest", "1.0"},
+				imageBar: {
+					digest111: {tagLatest, tag1},
 				},
 			},
 			registry.RegInvImage{
-				"bar": {
-					"sha256:111": {"1.0"},
+				imageBar: {
+					digest111: {tag1},
 				},
 			},
 			nil,
@@ -220,14 +232,14 @@ func TestApplyFilters(t *testing.T) {
 		{
 			"filter on 'latest' tag",
 			manifest.GrowOptions{
-				FilterTags: []image.Tag{"latest"},
+				FilterTags: []image.Tag{tagLatest},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"latest", "2.0"},
+				imageFoo: {
+					digest000: {tagLatest, tag2},
 				},
-				"bar": {
-					"sha256:111": {"latest", "1.0"},
+				imageBar: {
+					digest111: {tagLatest, tag1},
 				},
 			},
 			registry.RegInvImage{},
@@ -236,20 +248,20 @@ func TestApplyFilters(t *testing.T) {
 		{
 			"filter on digest",
 			manifest.GrowOptions{
-				FilterDigests: []image.Digest{"sha256:222"},
+				FilterDigests: []image.Digest{digest222},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"latest", "2.0"},
-					"sha256:222": {"3.0"},
+				imageFoo: {
+					digest000: {tagLatest, tag2},
+					digest222: {tag3},
 				},
-				"bar": {
-					"sha256:111": {"latest", "1.0"},
+				imageBar: {
+					digest111: {tagLatest, tag1},
 				},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:222": {"3.0"},
+				imageFoo: {
+					digest222: {tag3},
 				},
 			},
 			nil,
@@ -257,23 +269,23 @@ func TestApplyFilters(t *testing.T) {
 		{
 			"filter on shared tag (multiple images share same tag)",
 			manifest.GrowOptions{
-				FilterTags: []image.Tag{"1.2.3"},
+				FilterTags: []image.Tag{tag123},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"latest", "1.2.3"},
-					"sha256:222": {"3.0"},
+				imageFoo: {
+					digest000: {tagLatest, tag123},
+					digest222: {tag3},
 				},
-				"bar": {
-					"sha256:111": {"latest", "1.2.3"},
+				imageBar: {
+					digest111: {tagLatest, tag123},
 				},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"1.2.3"},
+				imageFoo: {
+					digest000: {tag123},
 				},
-				"bar": {
-					"sha256:111": {"1.2.3"},
+				imageBar: {
+					digest111: {tag123},
 				},
 			},
 			nil,
@@ -281,21 +293,21 @@ func TestApplyFilters(t *testing.T) {
 		{
 			"filter on shared tag and image name (multiple images share same tag)",
 			manifest.GrowOptions{
-				FilterImages: []image.Name{"foo"},
-				FilterTags:   []image.Tag{"1.2.3"},
+				FilterImages: []image.Name{imageFoo},
+				FilterTags:   []image.Tag{tag123},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"latest", "1.2.3"},
-					"sha256:222": {"3.0"},
+				imageFoo: {
+					digest000: {tagLatest, tag123},
+					digest222: {tag3},
 				},
-				"bar": {
-					"sha256:111": {"latest", "1.2.3"},
+				imageBar: {
+					digest111: {tagLatest, tag123},
 				},
 			},
 			registry.RegInvImage{
-				"foo": {
-					"sha256:000": {"1.2.3"},
+				imageFoo: {
+					digest000: {tag123},
 				},
 			},
 			nil,

--- a/internal/promoter/image/sign_integration_test.go
+++ b/internal/promoter/image/sign_integration_test.go
@@ -46,6 +46,12 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
+const (
+	testTagV1     = "v1.0"
+	testImageApp  = "app"
+	testBuilderID = "https://k8s.io/promo-tools@test"
+)
+
 // newTLSTestRegistry starts an in-process OCI registry over TLS and returns
 // the host:port address and a DefaultPromoterImplementation configured with
 // a transport that trusts the test server's certificate.
@@ -93,10 +99,10 @@ func pushTestImage(t *testing.T, di *DefaultPromoterImplementation, ref string) 
 func testEdgeForHost(host string, digest image.Digest) promotion.Edge {
 	return promotion.Edge{
 		SrcRegistry: reg.Context{Name: image.Registry(host + "/staging"), Src: true},
-		SrcImageTag: promotion.ImageTag{Name: "myimage", Tag: "v1.0"},
+		SrcImageTag: promotion.ImageTag{Name: "myimage", Tag: testTagV1},
 		Digest:      digest,
 		DstRegistry: reg.Context{Name: image.Registry(host + "/production")},
-		DstImageTag: promotion.ImageTag{Name: "myimage", Tag: "v1.0"},
+		DstImageTag: promotion.ImageTag{Name: "myimage", Tag: testTagV1},
 	}
 }
 
@@ -183,7 +189,7 @@ func TestPushAttestation(t *testing.T) {
 		SrcRef:    edge.SrcReference(),
 		DstRef:    edge.DstReference(),
 		Digest:    string(edge.Digest),
-		BuilderId: "https://k8s.io/promo-tools@test",
+		BuilderId: testBuilderID,
 	}
 
 	gen := &fakeGenerator{data: []byte(`{"test": "attestation"}`)}
@@ -213,7 +219,7 @@ func TestPushAttestationIdempotent(t *testing.T) {
 		SrcRef:    edge.SrcReference(),
 		DstRef:    edge.DstReference(),
 		Digest:    string(edge.Digest),
-		BuilderId: "https://k8s.io/promo-tools@test",
+		BuilderId: testBuilderID,
 	}
 
 	gen := &fakeGenerator{data: []byte(`{"test": "attestation"}`)}
@@ -284,7 +290,7 @@ func TestPushAttestationCosignVerify(t *testing.T) {
 		SrcRef:    edge.SrcReference(),
 		DstRef:    edge.DstReference(),
 		Digest:    string(edge.Digest),
-		BuilderId: "https://k8s.io/promo-tools@test",
+		BuilderId: testBuilderID,
 	}
 
 	keypair, err := sgsign.NewEphemeralKeypair(nil)
@@ -371,8 +377,8 @@ func TestPromoteImagesCraneProvider(t *testing.T) {
 	}
 
 	entries := []entry{
-		{imgName: "app", tag: "v1.0"},
-		{imgName: "app", tag: "v2.0"},
+		{imgName: testImageApp, tag: testTagV1},
+		{imgName: testImageApp, tag: "v2.0"},
 		{imgName: "web", tag: "latest"},
 	}
 
@@ -418,7 +424,7 @@ func TestPromoteImagesCraneProvider(t *testing.T) {
 
 	tags, err := remote.List(repo, remote.WithTransport(di.getTransport()))
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"v1.0", "v2.0"}, tags)
+	require.ElementsMatch(t, []string{testTagV1, "v2.0"}, tags)
 }
 
 // TestWriteProvenanceAttestationsIdempotent verifies that running
@@ -439,10 +445,10 @@ func TestWriteProvenanceAttestationsIdempotent(t *testing.T) {
 	edges := map[promotion.Edge]any{
 		{
 			SrcRegistry: reg.Context{Name: srcRegistry, Src: true},
-			SrcImageTag: promotion.ImageTag{Name: "app", Tag: "v1.0"},
+			SrcImageTag: promotion.ImageTag{Name: testImageApp, Tag: testTagV1},
 			Digest:      image.Digest(digest),
 			DstRegistry: reg.Context{Name: dstRegistry},
-			DstImageTag: promotion.ImageTag{Name: "app", Tag: "v1.0"},
+			DstImageTag: promotion.ImageTag{Name: testImageApp, Tag: testTagV1},
 		}: nil,
 	}
 

--- a/internal/promoter/image/sign_test.go
+++ b/internal/promoter/image/sign_test.go
@@ -32,6 +32,8 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
+const testDigest = "sha256:709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f"
+
 func TestDigestToSignatureTag(t *testing.T) {
 	t.Parallel()
 
@@ -42,7 +44,7 @@ func TestDigestToSignatureTag(t *testing.T) {
 	}{
 		{
 			name:   "standard sha256 digest",
-			digest: "sha256:709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f",
+			digest: testDigest,
 			want:   "sha256-709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f.sig",
 		},
 		{
@@ -132,7 +134,7 @@ func TestTargetIdentity(t *testing.T) {
 			edge: &promotion.Edge{
 				DstRegistry: registry.Context{Name: "us-west2-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes"},
 				DstImageTag: promotion.ImageTag{Name: "conformance-arm64"},
-				Digest:      "sha256:709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f",
+				Digest:      testDigest,
 			},
 			assert: func(res string) {
 				require.Equal(t, "registry.k8s.io/kubernetes/conformance-arm64", res)
@@ -154,7 +156,7 @@ func TestTargetIdentity(t *testing.T) {
 			edge: &promotion.Edge{
 				DstRegistry: registry.Context{Name: "foo-bar"},
 				DstImageTag: promotion.ImageTag{Name: "conformance-arm64"},
-				Digest:      "sha256:709e17a9c17018997724ed19afc18dbf576e9af10dfe78c13b34175027916d8f",
+				Digest:      testDigest,
 			},
 			assert: func(res string) {
 				require.Equal(t, "foo-bar/conformance-arm64", res)

--- a/promoter/image/options/options_test.go
+++ b/promoter/image/options/options_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testRegistry = "gcr.io/test"
+
 func TestOptionsValidate(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
@@ -40,17 +42,17 @@ func TestOptionsValidate(t *testing.T) {
 		},
 		{
 			name:      "snapshot set",
-			opts:      Options{Snapshot: "gcr.io/test"},
+			opts:      Options{Snapshot: testRegistry},
 			shouldErr: false,
 		},
 		{
 			name:      "manifest based snapshot set",
-			opts:      Options{ManifestBasedSnapshotOf: "gcr.io/test"},
+			opts:      Options{ManifestBasedSnapshotOf: testRegistry},
 			shouldErr: false,
 		},
 		{
 			name:      "snapshot bypasses manifest check",
-			opts:      Options{Snapshot: "gcr.io/test"},
+			opts:      Options{Snapshot: testRegistry},
 			shouldErr: false,
 		},
 		{

--- a/promoter/image/promoter_test.go
+++ b/promoter/image/promoter_test.go
@@ -34,6 +34,11 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
+const (
+	testImageRef = "img@sha256:abc"
+	testMirror   = "mirror1"
+)
+
 // nonEmptyManifests returns a minimal manifest slice so that the pipeline
 // does not stop early due to an empty manifest list.
 func nonEmptyManifests() []schema.Manifest {
@@ -469,7 +474,7 @@ func TestCheckSignatures(t *testing.T) {
 			msg:       "FixMissingSignatures fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.GetSignatureStatusReturns(checkresults.Signature{
-					"img@sha256:abc": {Missing: []string{"mirror1"}},
+					testImageRef: {Missing: []string{testMirror}},
 				}, nil)
 				fpi.FixMissingSignaturesReturns(testErr)
 			},
@@ -479,7 +484,7 @@ func TestCheckSignatures(t *testing.T) {
 			msg:       "FixPartialSignatures fails",
 			prepare: func(fpi *imagefakes.FakePromoterImplementation) {
 				fpi.GetSignatureStatusReturns(checkresults.Signature{
-					"img@sha256:abc": {Signed: []string{"primary"}, Missing: []string{"mirror1"}},
+					testImageRef: {Signed: []string{"primary"}, Missing: []string{testMirror}},
 				}, nil)
 				fpi.FixPartialSignaturesReturns(testErr)
 			},
@@ -506,7 +511,7 @@ func TestCheckSignaturesAllConsistent(t *testing.T) {
 	mock := imagefakes.FakePromoterImplementation{}
 	// Return a result with no missing signatures
 	mock.GetSignatureStatusReturns(checkresults.Signature{
-		"img@sha256:abc": {Signed: []string{"primary", "mirror1"}},
+		testImageRef: {Signed: []string{"primary", testMirror}},
 	}, nil)
 	sut.SetImplementation(&mock)
 

--- a/promoter/image/promotion/edge_test.go
+++ b/promoter/image/promotion/edge_test.go
@@ -26,6 +26,16 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
+const (
+	testImageFoo        = "foo"
+	testImageBar        = "bar"
+	testMyImage         = "myimage"
+	testMyImageTag      = "v1.0"
+	testTagLatest       = "latest"
+	testStagingRegistry = "gcr.io/k8s-staging-foo"
+	testProdRegistry    = "us-docker.pkg.dev/k8s-artifacts-prod/images/foo"
+)
+
 var (
 	testSrcRC = registry.Context{
 		Name:           "gcr.io/staging",
@@ -47,7 +57,7 @@ var (
 func TestEdgeSrcReference(t *testing.T) {
 	e := Edge{
 		SrcRegistry: testSrcRC,
-		SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
+		SrcImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		Digest:      testDigest1,
 	}
 	require.Equal(t, "gcr.io/staging/foo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", e.SrcReference())
@@ -59,7 +69,7 @@ func TestEdgeSrcReference(t *testing.T) {
 func TestEdgeDstReference(t *testing.T) {
 	e := Edge{
 		DstRegistry: testDstRC1,
-		DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+		DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		Digest:      testDigest1,
 	}
 	require.Equal(t, "us.gcr.io/prod/foo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", e.DstReference())
@@ -68,11 +78,11 @@ func TestEdgeDstReference(t *testing.T) {
 }
 
 func TestToFQIN(t *testing.T) {
-	require.Equal(t, "gcr.io/staging/foo@sha256:abc", ToFQIN("gcr.io/staging", "foo", "sha256:abc"))
+	require.Equal(t, "gcr.io/staging/foo@sha256:abc", ToFQIN("gcr.io/staging", testImageFoo, "sha256:abc"))
 }
 
 func TestToPQIN(t *testing.T) {
-	require.Equal(t, "gcr.io/staging/foo:v1", ToPQIN("gcr.io/staging", "foo", "v1"))
+	require.Equal(t, "gcr.io/staging/foo:v1", ToPQIN("gcr.io/staging", testImageFoo, "v1"))
 }
 
 func testManifest() schema.Manifest {
@@ -85,9 +95,9 @@ func testManifest() schema.Manifest {
 		},
 		Images: []registry.Image{
 			{
-				Name: "foo",
+				Name: testImageFoo,
 				Dmap: registry.DigestTags{
-					testDigest1: {"v1", "latest"},
+					testDigest1: {"v1", testTagLatest},
 				},
 			},
 		},
@@ -117,7 +127,7 @@ func TestToEdgesTagless(t *testing.T) {
 		},
 		Images: []registry.Image{
 			{
-				Name: "bar",
+				Name: testImageBar,
 				Dmap: registry.DigestTags{
 					testDigest1: {}, // tagless
 				},
@@ -137,10 +147,10 @@ func TestCheckOverlappingEdgesClean(t *testing.T) {
 	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
-			SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			SrcImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 			Digest:      testDigest1,
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		}: nil,
 	}
 	checked, err := CheckOverlappingEdges(edges)
@@ -153,17 +163,17 @@ func TestCheckOverlappingEdgesConflict(t *testing.T) {
 	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
-			SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			SrcImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 			Digest:      testDigest1,
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		}: nil,
 		{
 			SrcRegistry: testSrcRC,
-			SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			SrcImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 			Digest:      testDigest2,
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		}: nil,
 	}
 	_, err := CheckOverlappingEdges(edges)
@@ -175,28 +185,28 @@ func TestGetPromotionCandidates(t *testing.T) {
 	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
-			SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			SrcImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 			Digest:      testDigest1,
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		}: nil,
 		{
 			SrcRegistry: testSrcRC,
-			SrcImageTag: ImageTag{Name: "bar", Tag: "v2"},
+			SrcImageTag: ImageTag{Name: testImageBar, Tag: "v2"},
 			Digest:      testDigest2,
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "bar", Tag: "v2"},
+			DstImageTag: ImageTag{Name: testImageBar, Tag: "v2"},
 		}: nil,
 	}
 
 	// Inventory where "foo:v1" is already promoted but "bar:v2" is not.
 	inv := map[image.Registry]registry.RegInvImage{
 		testSrcRC.Name: {
-			"foo": registry.DigestTags{testDigest1: {"v1"}},
-			"bar": registry.DigestTags{testDigest2: {"v2"}},
+			testImageFoo: registry.DigestTags{testDigest1: {"v1"}},
+			testImageBar: registry.DigestTags{testDigest2: {"v2"}},
 		},
 		testDstRC1.Name: {
-			"foo": registry.DigestTags{testDigest1: {"v1"}}, // already promoted
+			testImageFoo: registry.DigestTags{testDigest1: {"v1"}}, // already promoted
 		},
 	}
 
@@ -205,27 +215,27 @@ func TestGetPromotionCandidates(t *testing.T) {
 	require.Len(t, candidates, 1)
 
 	for edge := range candidates {
-		require.Equal(t, image.Name("bar"), edge.DstImageTag.Name)
+		require.Equal(t, image.Name(testImageBar), edge.DstImageTag.Name)
 	}
 }
 
 func TestGetPromotionCandidatesTagMove(t *testing.T) {
 	edge := Edge{
 		SrcRegistry: testSrcRC,
-		SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
+		SrcImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		Digest:      testDigest1,
 		DstRegistry: testDstRC1,
-		DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+		DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 	}
 	edges := map[Edge]any{edge: nil}
 
 	// Tag "v1" in dst points to a different digest — tag move.
 	inv := map[image.Registry]registry.RegInvImage{
 		testSrcRC.Name: {
-			"foo": registry.DigestTags{testDigest1: {"v1"}},
+			testImageFoo: registry.DigestTags{testDigest1: {"v1"}},
 		},
 		testDstRC1.Name: {
-			"foo": registry.DigestTags{testDigest2: {"v1"}},
+			testImageFoo: registry.DigestTags{testDigest2: {"v1"}},
 		},
 	}
 
@@ -237,18 +247,18 @@ func TestGetPromotionCandidatesTagMove(t *testing.T) {
 func TestVertexProps(t *testing.T) {
 	edge := Edge{
 		SrcRegistry: testSrcRC,
-		SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
+		SrcImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		Digest:      testDigest1,
 		DstRegistry: testDstRC1,
-		DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+		DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 	}
 
 	inv := map[image.Registry]registry.RegInvImage{
 		testSrcRC.Name: {
-			"foo": registry.DigestTags{testDigest1: {"v1"}},
+			testImageFoo: registry.DigestTags{testDigest1: {"v1"}},
 		},
 		testDstRC1.Name: {
-			"foo": registry.DigestTags{testDigest1: {"v1"}},
+			testImageFoo: registry.DigestTags{testDigest1: {"v1"}},
 		},
 	}
 
@@ -262,15 +272,15 @@ func TestVertexProps(t *testing.T) {
 func TestVertexPropsNotPromoted(t *testing.T) {
 	edge := Edge{
 		SrcRegistry: testSrcRC,
-		SrcImageTag: ImageTag{Name: "foo", Tag: "v1"},
+		SrcImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 		Digest:      testDigest1,
 		DstRegistry: testDstRC1,
-		DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+		DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 	}
 
 	inv := map[image.Registry]registry.RegInvImage{
 		testSrcRC.Name: {
-			"foo": registry.DigestTags{testDigest1: {"v1"}},
+			testImageFoo: registry.DigestTags{testDigest1: {"v1"}},
 		},
 		// Destination registry is empty.
 	}
@@ -285,45 +295,45 @@ func TestEdgesToRegInvImage(t *testing.T) {
 	edges := map[Edge]any{
 		{
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "foo", Tag: "v1"},
+			DstImageTag: ImageTag{Name: testImageFoo, Tag: "v1"},
 			Digest:      testDigest1,
 		}: nil,
 		{
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "foo", Tag: "v2"},
+			DstImageTag: ImageTag{Name: testImageFoo, Tag: "v2"},
 			Digest:      testDigest1,
 		}: nil,
 		{
 			DstRegistry: testDstRC2,
-			DstImageTag: ImageTag{Name: "bar", Tag: "latest"},
+			DstImageTag: ImageTag{Name: testImageBar, Tag: testTagLatest},
 			Digest:      testDigest2,
 		}: nil,
 	}
 
 	rii := EdgesToRegInvImage(edges, "us.gcr.io/prod")
 	require.Len(t, rii, 1) // only "foo" from us.gcr.io/prod
-	require.Contains(t, rii, image.Name("foo"))
-	require.Len(t, rii["foo"][testDigest1], 2)
+	require.Contains(t, rii, image.Name(testImageFoo))
+	require.Len(t, rii[testImageFoo][testDigest1], 2)
 }
 
 func TestFilterByTag(t *testing.T) {
 	rii := registry.RegInvImage{
-		"foo": registry.DigestTags{
-			testDigest1: {"v1", "latest"},
+		testImageFoo: registry.DigestTags{
+			testDigest1: {"v1", testTagLatest},
 			testDigest2: {"v2"},
 		},
 	}
 
 	filtered := FilterByTag(rii, "v1")
 	require.Len(t, filtered, 1)
-	require.Contains(t, filtered, image.Name("foo"))
-	require.Len(t, filtered["foo"], 1)
-	require.Contains(t, filtered["foo"], testDigest1)
+	require.Contains(t, filtered, image.Name(testImageFoo))
+	require.Len(t, filtered[testImageFoo], 1)
+	require.Contains(t, filtered[testImageFoo], testDigest1)
 }
 
 func TestFilterByTagNoMatch(t *testing.T) {
 	rii := registry.RegInvImage{
-		"foo": registry.DigestTags{
+		testImageFoo: registry.DigestTags{
 			testDigest1: {"v1"},
 		},
 	}
@@ -336,9 +346,9 @@ func TestGetRegistriesToRead(t *testing.T) {
 	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
-			SrcImageTag: ImageTag{Name: "foo"},
+			SrcImageTag: ImageTag{Name: testImageFoo},
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "foo"},
+			DstImageTag: ImageTag{Name: testImageFoo},
 		}: nil,
 	}
 
@@ -358,15 +368,15 @@ func TestGetBaseRegistries(t *testing.T) {
 	edges := map[Edge]any{
 		{
 			SrcRegistry: testSrcRC,
-			SrcImageTag: ImageTag{Name: "foo"},
+			SrcImageTag: ImageTag{Name: testImageFoo},
 			DstRegistry: testDstRC1,
-			DstImageTag: ImageTag{Name: "foo"},
+			DstImageTag: ImageTag{Name: testImageFoo},
 		}: nil,
 		{
 			SrcRegistry: testSrcRC,
-			SrcImageTag: ImageTag{Name: "bar"},
+			SrcImageTag: ImageTag{Name: testImageBar},
 			DstRegistry: testDstRC2,
-			DstImageTag: ImageTag{Name: "bar"},
+			DstImageTag: ImageTag{Name: testImageBar},
 		}: nil,
 	}
 
@@ -388,19 +398,19 @@ func TestGetPromotionCandidatesWithBaseRegistries(t *testing.T) {
 	// When ReadRegistries uses base registries for splitByKnownRegistries,
 	// the inventory is keyed correctly and digests are found.
 	srcReg := registry.Context{
-		Name: "gcr.io/k8s-staging-foo",
+		Name: testStagingRegistry,
 		Src:  true,
 	}
 	dstReg := registry.Context{
-		Name: "us-docker.pkg.dev/k8s-artifacts-prod/images/foo",
+		Name: testProdRegistry,
 	}
 
 	edges := map[Edge]any{
 		{
 			SrcRegistry: srcReg,
-			SrcImageTag: ImageTag{Name: "myimage", Tag: "v1.0"},
+			SrcImageTag: ImageTag{Name: testMyImage, Tag: testMyImageTag},
 			DstRegistry: dstReg,
-			DstImageTag: ImageTag{Name: "myimage", Tag: "v1.0"},
+			DstImageTag: ImageTag{Name: testMyImage, Tag: testMyImageTag},
 			Digest:      testDigest1,
 		}: nil,
 	}
@@ -409,14 +419,14 @@ func TestGetPromotionCandidatesWithBaseRegistries(t *testing.T) {
 	// (this is the correct keying produced when base registries are used).
 	// Both src and dst have the digest+tag → already promoted.
 	inv := map[image.Registry]registry.RegInvImage{
-		"gcr.io/k8s-staging-foo": {
-			"myimage": registry.DigestTags{
-				testDigest1: {"v1.0"},
+		testStagingRegistry: {
+			testMyImage: registry.DigestTags{
+				testDigest1: {testMyImageTag},
 			},
 		},
-		"us-docker.pkg.dev/k8s-artifacts-prod/images/foo": {
-			"myimage": registry.DigestTags{
-				testDigest1: {"v1.0"},
+		testProdRegistry: {
+			testMyImage: registry.DigestTags{
+				testDigest1: {testMyImageTag},
 			},
 		},
 	}
@@ -428,13 +438,13 @@ func TestGetPromotionCandidatesWithBaseRegistries(t *testing.T) {
 
 	// Now test with a digest that needs promotion (exists in src, not in dst).
 	inv = map[image.Registry]registry.RegInvImage{
-		"gcr.io/k8s-staging-foo": {
-			"myimage": registry.DigestTags{
-				testDigest1: {"v1.0"},
+		testStagingRegistry: {
+			testMyImage: registry.DigestTags{
+				testDigest1: {testMyImageTag},
 			},
 		},
-		"us-docker.pkg.dev/k8s-artifacts-prod/images/foo": {
-			"myimage": registry.DigestTags{},
+		testProdRegistry: {
+			testMyImage: registry.DigestTags{},
 		},
 	}
 
@@ -448,7 +458,7 @@ func TestGetPromotionCandidatesWithBaseRegistries(t *testing.T) {
 	invBadKeys := map[image.Registry]registry.RegInvImage{
 		"gcr.io/k8s-staging-foo/myimage": {
 			"": registry.DigestTags{
-				testDigest1: {"v1.0"},
+				testDigest1: {testMyImageTag},
 			},
 		},
 	}

--- a/promoter/image/ratelimit/retry.go
+++ b/promoter/image/ratelimit/retry.go
@@ -49,8 +49,7 @@ func IsTransient(err error) bool {
 		return true
 	}
 
-	var terr *transport.Error
-	if errors.As(err, &terr) {
+	if terr, ok := errors.AsType[*transport.Error](err); ok {
 		return terr.StatusCode == http.StatusTooManyRequests ||
 			terr.StatusCode >= http.StatusInternalServerError
 	}

--- a/promoter/image/ratelimit/roundtripper_test.go
+++ b/promoter/image/ratelimit/roundtripper_test.go
@@ -66,7 +66,7 @@ func TestRoundTripRateLimitsAllMethods(t *testing.T) {
 			t.Fatalf("creating %s request: %v", method, err)
 		}
 
-		resp, err := client.Do(req) //nolint:gosec // httptest URL
+		resp, err := client.Do(req)
 		if err != nil {
 			t.Fatalf("%s request failed: %v", method, err)
 		}
@@ -104,7 +104,7 @@ func TestAdaptiveBackoffOn429(t *testing.T) {
 		t.Fatalf("creating request: %v", err)
 	}
 
-	resp, reqErr := client.Do(req) //nolint:gosec // httptest URL
+	resp, reqErr := client.Do(req)
 	if reqErr != nil {
 		t.Fatalf("first request failed: %v", reqErr)
 	}
@@ -140,7 +140,7 @@ func TestStatsTracking(t *testing.T) {
 			t.Fatalf("creating request: %v", err)
 		}
 
-		resp, err := client.Do(req) //nolint:gosec // httptest URL
+		resp, err := client.Do(req)
 		if err != nil {
 			t.Fatalf("request failed: %v", err)
 		}

--- a/promoter/image/registry/crane_integration_test.go
+++ b/promoter/image/registry/crane_integration_test.go
@@ -124,14 +124,14 @@ func TestCraneProviderCopyMultipleTagsSameDigest(t *testing.T) {
 	// Promote the same digest to multiple tags in destination, simulating
 	// a manifest with dmap: {"sha256:...": ["v1.0", "latest"]}.
 	srcVertex := host + "/staging/myimage@" + digest
-	for _, tag := range []string{"v1.0", "latest"} {
+	for _, tag := range []string{testTagV1, testTagLatest} {
 		dstVertex := fmt.Sprintf("%s/production/myimage:%s", host, tag)
 		err := p.CopyImage(context.Background(), srcVertex, dstVertex)
 		require.NoError(t, err)
 	}
 
 	// Both tags should resolve to the same digest.
-	for _, tag := range []string{"v1.0", "latest"} {
+	for _, tag := range []string{testTagV1, testTagLatest} {
 		ref := fmt.Sprintf("%s/production/myimage:%s", host, tag)
 		gotDigest, err := crane.Digest(ref, crane.Insecure)
 		require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestCraneProviderCopyMultipleTagsSameDigest(t *testing.T) {
 
 	tags, err := crane.ListTags(host+"/production/myimage", crane.Insecure)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"v1.0", "latest"}, tags)
+	require.ElementsMatch(t, []string{testTagV1, testTagLatest}, tags)
 }
 
 func TestCraneProviderCopyNonexistentSource(t *testing.T) {
@@ -289,9 +289,9 @@ func TestCraneProviderPromoteImages(t *testing.T) {
 	}
 
 	entries := []imageEntry{
-		{name: "app", tag: "v1.0"},
+		{name: "app", tag: testTagV1},
 		{name: "app", tag: "v2.0"},
-		{name: "web", tag: "latest"},
+		{name: "web", tag: testTagLatest},
 	}
 
 	// Push all test images to the staging registry.
@@ -324,7 +324,7 @@ func TestCraneProviderPromoteImages(t *testing.T) {
 	// Verify tag listing for a multi-tag image.
 	tags, err := crane.ListTags(fmt.Sprintf("%s/app", dstRegistry), crane.Insecure)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"v1.0", "v2.0"}, tags)
+	require.ElementsMatch(t, []string{testTagV1, "v2.0"}, tags)
 }
 
 func TestCraneProviderCopyImageIndex(t *testing.T) {

--- a/promoter/image/registry/provider_test.go
+++ b/promoter/image/registry/provider_test.go
@@ -24,9 +24,15 @@ import (
 	"sigs.k8s.io/promo-tools/v4/types/image"
 )
 
+const (
+	testTagV1           = "v1.0"
+	testTagLatest       = "latest"
+	testStagingRegistry = "gcr.io/k8s-staging-foo"
+)
+
 func TestRegistryConfigFromContext(t *testing.T) {
 	rc := Context{
-		Name:           "gcr.io/k8s-staging-foo",
+		Name:           testStagingRegistry,
 		ServiceAccount: "sa@project.iam.gserviceaccount.com",
 		Src:            true,
 	}
@@ -85,7 +91,7 @@ func TestFakeProviderAddImage(t *testing.T) {
 	reg := image.Registry("gcr.io/test")
 	name := image.Name("myimage")
 	digest := image.Digest("sha256:abc123")
-	tags := []image.Tag{"v1.0", "latest"}
+	tags := []image.Tag{testTagV1, testTagLatest}
 
 	f.AddImage(reg, name, digest, tags...)
 
@@ -156,7 +162,7 @@ func TestFakeProviderCopyImageError(t *testing.T) {
 
 func TestSplitByKnownRegistries(t *testing.T) {
 	registries := []RegistryConfig{
-		{Name: "gcr.io/k8s-staging-foo"},
+		{Name: testStagingRegistry},
 		{Name: "us-docker.pkg.dev/k8s-artifacts-prod/images"},
 	}
 
@@ -168,12 +174,12 @@ func TestSplitByKnownRegistries(t *testing.T) {
 	}{
 		{
 			fullName: "gcr.io/k8s-staging-foo/myimage",
-			wantReg:  "gcr.io/k8s-staging-foo",
+			wantReg:  testStagingRegistry,
 			wantImg:  "myimage",
 		},
 		{
 			fullName: "gcr.io/k8s-staging-foo/sub/path/image",
-			wantReg:  "gcr.io/k8s-staging-foo",
+			wantReg:  testStagingRegistry,
 			wantImg:  "sub/path/image",
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR bumps golangci-lint to v2.13 and fixes all nits surfaced by the bump.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @cpanato @saschagrunert 

Bumped the installer in the job, config file and all nits.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
